### PR TITLE
passport-local, github2 로그인, 로그아웃 구현, express-session 적용 완료

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -32,6 +32,14 @@ app.use(passport.session());
 passportConfig();
 
 app.use('/api', apiRouter);
+app.all('*', (req, res) => {
+  if (process.env.MODE === 'dev') {
+    res.redirect(process.env.DEV_URL);
+    return;
+  }
+  // TODO : sendFile 경로 수정 -> frontend build 결과물의 index.html로 변경
+  res.sendFile(path.join(__dirname, 'public/index.html'));
+});
 
 app.use((req, res, next) => {
   next(createError(404));

--- a/backend/app.js
+++ b/backend/app.js
@@ -7,8 +7,11 @@ import cookieParser from 'cookie-parser';
 import logger from 'morgan';
 import passport from 'passport';
 import cors from 'cors';
+import session from 'express-session';
+import config from '@config';
 
 import apiRouter from './routes/api/index';
+import passportConfig from './lib/passport';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -19,7 +22,14 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(session(config.session)); // 세션, 쿠키 유효시간 설정-> config.js파일 변경
+app.use((req, res, next) => {
+  res.locals.session = req.session;
+  next();
+});
 app.use(passport.initialize());
+app.use(passport.session());
+passportConfig();
 
 app.use('/api', apiRouter);
 
@@ -33,7 +43,7 @@ app.use((err, req, res, next) => {
   console.error(err.message);
 
   res.status(err.status || 500);
-  res.json({ error: err.status || 500 });
+  res.json({ message: err.message });
 });
 
 app.listen(port, () => {

--- a/backend/lib/constants.js
+++ b/backend/lib/constants.js
@@ -1,0 +1,4 @@
+export const AUTH = {
+  GITHUB: 'GITHUB',
+  DEFAULT: 'DEFAULT',
+};

--- a/backend/lib/db.js
+++ b/backend/lib/db.js
@@ -1,5 +1,5 @@
 import mysql2 from 'mysql2/promise';
-import config from '@config/config';
+import config from '@config';
 
 const pool = mysql2.createPool(config.db);
 

--- a/backend/lib/passport.js
+++ b/backend/lib/passport.js
@@ -1,10 +1,21 @@
 import passport from 'passport';
 import { Strategy as LocalStrategy } from 'passport-local';
 import { Strategy as GitHubStrategy } from 'passport-github2';
+import { userModel } from '@models';
 import config from '@config';
 import bcrypt from 'bcrypt';
 
 export default () => {
+  passport.serializeUser((user, done) => {
+    // 로그인 성공시 1번 호출되어 사용자의 식별자를 세션저장소에 저장, 두 번째 매개변수는 추후 req.user로 접근 가능
+    done(null, user.id);
+  });
+
+  passport.deserializeUser((user, done) => {
+    // 세션에 저장된 데이터를 기준으로 필요한 정보를 조회할 때 사용
+    done(null, user);
+  });
+
   const {
     clientID,
     clientSecret,
@@ -19,11 +30,22 @@ export default () => {
         usernameField: 'id',
         passwordField: 'pw',
       },
-      (id, pw, done) => {
-        /*  TODO
-          ID, PW 검증 로직 작성 후 성공하면 done(null, user); 호출
-          실패하면 done(err); 호출
-        */
+      async (id, pw, done) => {
+        const [[user]] = await userModel.getUserById({ id });
+        if (user) {
+          try {
+            const match = await bcrypt.compare(pw, user.pw);
+            if (match) {
+              done(null, user);
+              return;
+            }
+          } catch (err) {
+            done(err);
+          }
+        }
+        done(null, false, {
+          message: '아이디 또는 비밀번호가 일치하지 않습니다.',
+        });
       },
     ),
   );

--- a/backend/middlewares/auth.middleware.js
+++ b/backend/middlewares/auth.middleware.js
@@ -1,0 +1,7 @@
+export const authenticated = (req, res, next) => {
+  if (req.user) {
+    next();
+    return;
+  }
+  res.status(401).json({ message: '로그인이 필요합니다.' });
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,0 +1,1 @@
+export { userModel } from './user.model';

--- a/backend/models/user.model.js
+++ b/backend/models/user.model.js
@@ -1,8 +1,13 @@
 import pool from '@lib/db';
+import { AUTH } from '@lib/constants';
 
 export const userModel = {
   getUserById({ id }) {
     const sql = 'SELECT * FROM user WHERE id=?;';
     return pool.execute(sql, [id]);
+  },
+  addUser({ id, nickname, auth }) {
+    const sql = 'INSERT INTO user (id, nickname, auth) VALUES (?, ?, ?);';
+    return pool.execute(sql, [id, nickname, auth ? auth : AUTH.DEFAULT]);
   },
 };

--- a/backend/models/user.model.js
+++ b/backend/models/user.model.js
@@ -1,0 +1,8 @@
+import pool from '@lib/db';
+
+export const userModel = {
+  getUserById({ id }) {
+    const sql = 'SELECT * FROM user WHERE id=?;';
+    return pool.execute(sql, [id]);
+  },
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2299,6 +2299,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -2989,6 +2994,15 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {
@@ -3990,6 +4004,107 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "express-mysql-session": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/express-mysql-session/-/express-mysql-session-2.1.4.tgz",
+      "integrity": "sha512-Fcq168xVI8jtIJLhVHLJvBCvJlHnFWCcPmtt93UrWH38T2YsB919KrMCCh57/YkECkfff/L5zTQ95K1DxfOixg==",
+      "requires": {
+        "debug": "4.1.1",
+        "express-session": "1.17.0",
+        "mysql": "2.18.1",
+        "underscore": "1.9.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "express-session": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.0.tgz",
+          "integrity": "sha512-t4oX2z7uoSqATbMfsxWMbNjAL0T5zpvcJCk3Z9wnPPN7ibddhnmDZXHfEcoBMG2ojKXZoCyPMc5FbtK+G7SoDg==",
+          "requires": {
+            "cookie": "0.4.0",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "~2.0.0",
+            "on-headers": "~1.0.2",
+            "parseurl": "~1.3.3",
+            "safe-buffer": "5.2.0",
+            "uid-safe": "~2.1.5"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        }
+      }
+    },
+    "express-session": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.1.tgz",
+      "integrity": "sha512-UbHwgqjxQZJiWRTMyhvWGvjBQduGCSBDhhZXYenziMFjxst5rMV+aJZ6hKPHZnPyHGsrqRICxtX8jtEbm/z36Q==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.0",
+        "uid-safe": "~2.1.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         }
       }
     },
@@ -6567,6 +6682,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "mysql": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
+      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+      "requires": {
+        "bignumber.js": "9.0.0",
+        "readable-stream": "2.3.7",
+        "safe-buffer": "5.1.2",
+        "sqlstring": "2.3.1"
+      },
+      "dependencies": {
+        "sqlstring": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
+          "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
+        }
+      }
+    },
     "mysql2": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.2.5.tgz",
@@ -7474,6 +7607,11 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -8990,6 +9128,14 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
+      }
+    },
     "uid2": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
@@ -9020,6 +9166,11 @@
           "dev": true
         }
       }
+    },
+    "underscore": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start:dev": "nodemon --exec babel-node app.js",
+    "start:dev": "cross-env MODE=dev nodemon --exec babel-node app.js",
     "start:prod": "pm2 start app.js --interpreter node_modules/.bin/babel-node",
     "test": "jest"
   },
@@ -26,6 +26,8 @@
     "debug": "^4.2.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "express-mysql-session": "^2.1.4",
+    "express-session": "^1.17.1",
     "http-errors": "^1.8.0",
     "jsonwebtoken": "^8.5.1",
     "module-alias": "^2.2.2",
@@ -40,6 +42,7 @@
     "@babel/core": "^7.12.3",
     "@babel/node": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
+    "cross-env": "^7.0.2",
     "eslint": "^7.12.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^6.12.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start:dev": "cross-env MODE=dev nodemon --exec babel-node app.js",
-    "start:prod": "pm2 start app.js --interpreter node_modules/.bin/babel-node",
+    "start": "pm2 start app.js --interpreter node_modules/.bin/babel-node",
     "test": "jest"
   },
   "_moduleAliases": {

--- a/backend/routes/api/auth/auth.controller.js
+++ b/backend/routes/api/auth/auth.controller.js
@@ -1,0 +1,34 @@
+import passport from 'passport';
+
+/* 
+	POST /api/auth/login
+*/
+export const login = async (req, res, next) => {
+  passport.authenticate('local', (err, user, info) => {
+    if (err) {
+      next(err);
+      return;
+    }
+    if (!user) {
+      res.status(401).json({ message: '아이디 또는 비밀번호를 확인하세요.' });
+      return;
+    }
+    req.logIn(user, err => {
+      if (err) {
+        next(err);
+        return;
+      }
+      res.json({ id: user.id });
+    });
+  })(req, res, next);
+};
+
+/*
+	POST /api/auth/logout
+*/
+export const logout = async (req, res) => {
+  req.logout();
+  req.session.save(() => {
+    res.status(200).end();
+  });
+};

--- a/backend/routes/api/auth/github/github.controller.js
+++ b/backend/routes/api/auth/github/github.controller.js
@@ -1,0 +1,17 @@
+import passport from 'passport';
+
+export const login = passport.authenticate('github');
+
+export const handleAuth = passport.authenticate('github', {
+  failureRedirect: '/api/github/failure',
+});
+
+export const success = (req, res, next) => {
+  res.redirect('/');
+};
+
+export const failure = (req, res, next) => {
+  // TODO : failed 페이지로 리다이렉트
+  res.send('failed');
+  // res.status(401).json({ message: 'github auth failed' });
+};

--- a/backend/routes/api/auth/github/index.js
+++ b/backend/routes/api/auth/github/index.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import * as githubController from './github.controller';
+
+const router = express.Router();
+router.get('/', githubController.login);
+router.get('/callback', githubController.handleAuth, githubController.success);
+router.get('/failure', githubController.failure);
+
+export default router;

--- a/backend/routes/api/auth/index.js
+++ b/backend/routes/api/auth/index.js
@@ -1,8 +1,10 @@
 import express from 'express';
+import githubRouter from './github';
 import * as authController from './auth.controller';
 
 const router = express();
 
+router.use('/github', githubRouter);
 router.post('/login', authController.login);
 router.post('/logout', authController.logout);
 

--- a/backend/routes/api/auth/index.js
+++ b/backend/routes/api/auth/index.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import * as authController from './auth.controller';
+
+const router = express();
+
+router.post('/login', authController.login);
+router.post('/logout', authController.logout);
+
+export default router;

--- a/backend/routes/api/auth/index.js
+++ b/backend/routes/api/auth/index.js
@@ -2,7 +2,7 @@ import express from 'express';
 import githubRouter from './github';
 import * as authController from './auth.controller';
 
-const router = express();
+const router = express.Router();
 
 router.use('/github', githubRouter);
 router.post('/login', authController.login);

--- a/backend/routes/api/index.js
+++ b/backend/routes/api/index.js
@@ -1,5 +1,8 @@
 import express from 'express';
+import authRouter from './auth';
 
 const router = express.Router();
+
+router.use('/auth', authRouter);
 
 export default router;

--- a/backend/routes/api/index.js
+++ b/backend/routes/api/index.js
@@ -1,8 +1,10 @@
 import express from 'express';
 import authRouter from './auth';
+import issueRouter from './issues';
 
 const router = express.Router();
 
 router.use('/auth', authRouter);
+router.use('/issues', issueRouter);
 
 export default router;

--- a/backend/routes/api/issues/assignee/assignee.controller.js
+++ b/backend/routes/api/issues/assignee/assignee.controller.js
@@ -1,0 +1,11 @@
+export const addIssueAssignee = (req, res, next) => {
+  const { assignee_no } = req.params;
+  // TODO : 로직 작성
+  res.status(200).end();
+};
+
+export const deleteIssueAssignee = (req, res, next) => {
+  const { assignee_no } = req.params;
+  // TODO : 로직 작성
+  res.status(200).end();
+};

--- a/backend/routes/api/issues/assignee/index.js
+++ b/backend/routes/api/issues/assignee/index.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import * as assigneeController from './assignee.controller';
+
+const router = express.Router();
+
+router.post('/', assigneeController.addIssueAssignee);
+router.delete('/', assigneeController.deleteIssueAssignee);
+
+export default router;

--- a/backend/routes/api/issues/comment/comment.controller.js
+++ b/backend/routes/api/issues/comment/comment.controller.js
@@ -1,0 +1,16 @@
+export const getComments = (req, res, next) => {
+  // TODO : 로직 작성
+  res.json({ comments: [] });
+};
+export const addComment = (req, res, next) => {
+  // TODO : 로직 작성
+  res.status(200).end();
+};
+export const changeComment = (req, res, next) => {
+  // TODO : 로직 작성
+  res.status(200).end();
+};
+export const deleteComment = (req, res, next) => {
+  // TODO : 로직 작성
+  res.status(200).end();
+};

--- a/backend/routes/api/issues/comment/index.js
+++ b/backend/routes/api/issues/comment/index.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import * as commentController from './comment.controller';
+
+const router = express.Router();
+
+router.get('/', commentController.getComments);
+router.post('/', commentController.addComment);
+router.patch('/', commentController.changeComment);
+router.delete('/', commentController.deleteComment);
+
+export default router;

--- a/backend/routes/api/issues/index.js
+++ b/backend/routes/api/issues/index.js
@@ -1,0 +1,20 @@
+import express from 'express';
+import * as issuesController from './issues.controller';
+import titleRouter from './title';
+import assigneeRouter from './assignee';
+import labelRouter from './label';
+import milestoneRouter from './milestone';
+
+const router = express.Router();
+
+router.use('/title', titleRouter);
+router.use('/assignee', assigneeRouter);
+router.use('/label', labelRouter);
+router.use('/milestone', milestoneRouter);
+
+router.get('/', issuesController.getIssues);
+router.post('/', issuesController.addIssue);
+router.patch('/:no/close', issuesController.closeIssue);
+router.patch('/:no/open', issuesController.openIssue);
+
+export default router;

--- a/backend/routes/api/issues/issues.controller.js
+++ b/backend/routes/api/issues/issues.controller.js
@@ -1,0 +1,40 @@
+/**
+ * GET /api/issues
+ */
+export const getIssues = (req, res, next) => {
+  const { open, author, assignee, milestone, comment, label } = req.query;
+
+  // TODO : 해당 조건으로 검색하는 로직 구현
+  // 검색 조건 + '검색어'로 검색이 가능해야함!
+
+  res.json({ issues: [] });
+};
+
+/**
+ * POST /api/issues
+ */
+export const addIssue = (req, res, next) => {
+  // TODO : camelCase로 변경하는 것을 프론트에서 할지 여기서 할 지 결정
+  const { title, assignee_no, milestone_no, label_no } = req.body;
+
+  // TODO : 이슈 추가 로직 구현
+  res.status(201).end();
+};
+
+/**
+ * PATCH /api/issues/:no/close
+ */
+export const closeIssue = (req, res, next) => {
+  const { no } = req.params;
+  // TODO : 로직 작성
+  res.status(200).end();
+};
+
+/**
+ * PATCH /api/issues/:no/open
+ */
+export const openIssue = (req, res, next) => {
+  const { no } = req.params;
+  // TODO : 로직 작성
+  res.status(200).end();
+};

--- a/backend/routes/api/issues/label/index.js
+++ b/backend/routes/api/issues/label/index.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import * as labelController from './label.controller';
+
+const router = express.Router();
+
+router.post('/', labelController.addIssueLabel);
+router.delete('/', labelController.deleteIssueLabel);
+
+export default router;

--- a/backend/routes/api/issues/label/label.controller.js
+++ b/backend/routes/api/issues/label/label.controller.js
@@ -1,0 +1,11 @@
+export const addIssueLabel = (req, res, next) => {
+  const { label_no } = req.params;
+  // TODO : 로직 작성
+  res.status(200).end();
+};
+
+export const deleteIssueLabel = (req, res, next) => {
+  const { label_no } = req.params;
+  // TODO : 로직 작성
+  res.status(200).end();
+};

--- a/backend/routes/api/issues/milestone/index.js
+++ b/backend/routes/api/issues/milestone/index.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as milestoneController from './milestone.controller';
+
+const router = express.Router();
+
+router.patch('/', milestoneController.changeMilestone);
+
+export default router;

--- a/backend/routes/api/issues/milestone/milestone.controller.js
+++ b/backend/routes/api/issues/milestone/milestone.controller.js
@@ -1,0 +1,5 @@
+export const changeMilestone = (req, res, next) => {
+  const { milestone_no } = req.params;
+  // TODO : 로직 작성
+  res.status(200).end();
+};

--- a/backend/routes/api/issues/title/index.js
+++ b/backend/routes/api/issues/title/index.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as titleController from './title.controller';
+
+const router = express.Router();
+
+router.patch('/', titleController.changeTitle);
+
+export default router;

--- a/backend/routes/api/issues/title/title.controller.js
+++ b/backend/routes/api/issues/title/title.controller.js
@@ -1,0 +1,7 @@
+export const changeTitle = (req, res, next) => {
+  const { no } = req.params;
+
+  // TODO : title 변경 로직 구현
+
+  res.status(200).end();
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1932,6 +1932,14 @@
 						"integrity": "sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==",
 						"dev": true
 				},
+				"axios": {
+						"version": "0.21.0",
+						"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+						"integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+						"requires": {
+								"follow-redirects": "^1.10.0"
+						}
+				},
 				"axobject-query": {
 						"version": "2.2.0",
 						"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -4347,8 +4355,7 @@
 				"follow-redirects": {
 						"version": "1.13.0",
 						"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-						"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-						"dev": true
+						"integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
 				},
 				"for-in": {
 						"version": "1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "axios": "^0.21.0",
     "core-js": "^3.6.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,19 +1,41 @@
 import React from 'react';
 import styled from 'styled-components';
+import { API } from '@api';
 
 const App = () => {
+  const handleLogout = async e => {
+    e.preventDefault();
+    const { data, status } = await API.post('/api/auth/logout');
+    console.log('logout', data, status);
+  };
+
   return (
     <div className="container">
-      <Button>styled-components!!</Button>
+      <Button>
+        <a href="/api/auth/github">github 로그인</a>
+      </Button>
+      <LogoutButton onClick={handleLogout}>로그아웃</LogoutButton>
     </div>
   );
 };
 
 const Button = styled.button`
   padding: 1rem;
+  margin: 1rem;
   background-color: #29b6af;
   border: none;
   color: white;
+  display: block;
+  cursor: pointer;
+`;
+
+const LogoutButton = styled.button`
+  padding: 1rem;
+  margin: 1rem;
+  color: #29b6af;
+  border: 1px solid #29b6af;
+  background-color: white;
+  display: block;
   cursor: pointer;
 `;
 

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -29,7 +29,7 @@ instance.interceptors.response.use(
   },
 );
 
-export const apiClient = {
+export const API = {
   get(url, headers, cancelToken) {
     return instance({
       url,


### PR DESCRIPTION
### 1. passport-local
- 로컬 로그인 구현 완료 했습니다.
- 아직 프론트에 표현은 안했고, postman으로 테스트만 완료했습니다.
- bcrypt도 처리했습니다.

### 2.  passport-github2 로그인, 로그아웃 구현
- 깃헙 로그인 구현했습니다.
- 프론트에 깃헙 로그인 버튼이랑 로그아웃 버튼 임시로 구현했고, 테스트 완료했습니다.

### 3. express-session 적용 완료
- mysqlStore 이용해서 세션을 db에 저장하도록 구현했습니다.

### 4. cross-env 적용으로 dev/prod 환경 분리
- 깃헙의 OAuth callback url을 1개 밖에 입력을 못하더라구요. 그래서 dev용 앱과 prod용 앱을 만들어서 github 관련 config를 분리했습니다. ( 1cd02f9 이 커밋 참고해주세요. )
 
### 4. API 문서 수정
- 지금 API문서에 이슈 관련 uri가 대부분 잘못 설계되어서 수정본을 작성해봤는데, 함께 논의해보면 좋을 듯 합니다.
- 수정 문서 안에 수정내용 작성해놨습니다. 위키랑 hackMD 두 개 링크 걸어놨으니 편한걸로 보시면 됩니다.
-  #32  <--- 요거로 들어가시면 됩니다
- 그래서 API 문서대로 라우팅 구현하는 작업은 잠시 보류했습니다. (마지막 커밋  0b0fbd8)

##  🔊그리고 PR 컨벤션 정하면 좋을 것 같아요!