### PR TITLE
[WEB] #42 전체 이슈 가져오기 및 필터링 옵션에 따라 필터링 로직 구현

### DIFF
--- a/backend/lib/passport.js
+++ b/backend/lib/passport.js
@@ -9,7 +9,7 @@ import bcrypt from 'bcrypt';
 export default () => {
   passport.serializeUser((user, done) => {
     // 로그인 성공시 1번 호출되어 사용자의 식별자를 세션저장소에 저장, 두 번째 매개변수는 추후 req.user로 접근 가능
-    done(null, user.id);
+    done(null, user.nickname);
   });
 
   passport.deserializeUser((user, done) => {

--- a/backend/models/comment.model.js
+++ b/backend/models/comment.model.js
@@ -1,0 +1,10 @@
+import pool from '@lib/db';
+
+export const commentModel = {
+  getComments() {
+    const sql = `SELECT no, issue_no as issueNo, author_no as authorNo, content, is_head as isHead, 
+    created_at as createdAt, updated_at as updatedAt 
+    from comment ORDER BY issue_no;`;
+    return pool.query(sql);
+  },
+};

--- a/backend/models/comment.model.js
+++ b/backend/models/comment.model.js
@@ -2,9 +2,12 @@ import pool from '@lib/db';
 
 export const commentModel = {
   getComments() {
-    const sql = `SELECT no, issue_no as issueNo, author_no as authorNo, content, is_head as isHead, 
-    created_at as createdAt, updated_at as updatedAt 
-    from comment ORDER BY issue_no;`;
+    const sql = `SELECT c.no, c.issue_no as issueNo, u.nickname as author, c.content, c.is_head as isHead, 
+    c.created_at as createdAt, c.updated_at as updatedAt 
+    from comment c
+    LEFT JOIN user u
+    ON c.author_no = u.no
+    ORDER BY issue_no;`;
     return pool.query(sql);
   },
 };

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -3,3 +3,4 @@ export { issueModel } from './issue.model';
 export { milestoneModel } from './milestone.model';
 export { labelModel } from './label.model';
 export { assigneeModel } from './assignee.model';
+export { commentModel } from './comment.model';

--- a/backend/models/issue.model.js
+++ b/backend/models/issue.model.js
@@ -4,18 +4,37 @@ import pool from '@lib/db';
 
 export const issueModel = {
   /* prettier-ignore */
-  getIssueList({ isOpened, author, assignee, milestone, comment, label, keyword }) {
-    const sql = 'SELECT * FROM issue WHERE open=?;';
-    return pool.execute(sql, [open]);
+  getIssueList() {
+    const sql = `SELECT i.no, u.nickname as author, i.title, i.is_opened as isOpened, i.created_at as createdAt, 
+    i.closed_at as closedAt, m.title as milestone, (SELECT COUNT(comment.no) FROM comment WHERE issue_no=i.no) as commentCount 
+    FROM issue i 
+    LEFT JOIN milestone m ON m.no = i.milestone_no
+    LEFT JOIN user u ON u.no = i.author_no
+    ORDER BY i.no;`;
+    return pool.query(sql);
   },
   getIssueByNo({ no }) {
-    const sql = 'SELECT * FROM issue WHERE no=';
-    return pool.execute(sql);
+    const sql = 'SELECT * FROM issue WHERE no=?;';
+    return pool.execute(sql, [no]);
   },
-  addIssue({ authorNo, title, milestoneNo }) {
-    const issueSql =
+  addIssue({ title, authorNo, milestoneNo }) {
+    const sql =
       'INSERT INTO issue (title, author_no, milestone_no) VALUES (?, ?, ?);';
-    return pool.execute(issueSql, [title, authorNo, milestoneNo]);
+    return pool.execute(sql, [title, authorNo, milestoneNo]);
+  },
+  getIssuesLableList() {
+    const sql = `SELECT il.issue_no as issueNo, l.no, l.name, l.description, l.color 
+      FROM issue_label il 
+      LEFT JOIN label l ON il.label_no = l.no 
+      ORDER BY il.issue_no, l.no;`;
+    return pool.query(sql);
+  },
+  getIssuesAssigneeList() {
+    const sql = `SELECT a.issue_no as issueNo, a.user_no as userNo, u.nickname as nickname, u.pw, u.image 
+      FROM assignee a 
+      LEFT JOIN user u ON u.no = a.user_no
+      ORDER BY a.issue_no, u.no;`;
+    return pool.query(sql);
   },
   changeIssueTitle({}) {},
   addIssueAssignee({}) {},

--- a/backend/models/issue.model.js
+++ b/backend/models/issue.model.js
@@ -4,13 +4,12 @@ import pool from '@lib/db';
 
 export const issueModel = {
   /* prettier-ignore */
-  getIssueList(filterOptions = '') {
+  getIssueList() {
     const sql = `SELECT i.no, u.nickname as author, i.title, i.is_opened as isOpened, i.created_at as createdAt, 
-    i.closed_at as closedAt, m.title as milestone, (SELECT COUNT(comment.no) FROM comment WHERE issue_no=i.no) as commentCount 
+    i.closed_at as closedAt, m.title as milestone
     FROM issue i 
     LEFT JOIN milestone m ON m.no = i.milestone_no
     LEFT JOIN user u ON u.no = i.author_no
-    ${filterOptions}
     ORDER BY i.no;`;
     return pool.query(sql);
   },

--- a/backend/models/issue.model.js
+++ b/backend/models/issue.model.js
@@ -4,12 +4,13 @@ import pool from '@lib/db';
 
 export const issueModel = {
   /* prettier-ignore */
-  getIssueList() {
+  getIssueList(filterOptions = '') {
     const sql = `SELECT i.no, u.nickname as author, i.title, i.is_opened as isOpened, i.created_at as createdAt, 
     i.closed_at as closedAt, m.title as milestone, (SELECT COUNT(comment.no) FROM comment WHERE issue_no=i.no) as commentCount 
     FROM issue i 
     LEFT JOIN milestone m ON m.no = i.milestone_no
     LEFT JOIN user u ON u.no = i.author_no
+    ${filterOptions}
     ORDER BY i.no;`;
     return pool.query(sql);
   },

--- a/backend/routes/api/issues/issues.controller.js
+++ b/backend/routes/api/issues/issues.controller.js
@@ -3,13 +3,21 @@ import { issueModel } from '@models';
  * GET /api/issues
  */
 export const getIssues = async (req, res, next) => {
-  const { open, author, assignee, milestone, comment, label } = req.query;
+  const { isOpened, author, assignee, milestone, comment, label } = req.query;
+
+  // let filterOptionSql = 'WHERE ';
+  // const options = [];
+  // if(author) options.push(`u.nickname = ${author}`);
+  // if(assignee) {
+  //   // options.push(`assignee = ${author}`);
+  // }
+  // if(milestone) options.push(`m.title = ${milestone}`);
+  // if(comment) options.push(`author = ${author}`);
+  // if(author) options.push(`author = ${author}`);
 
   const [issues] = await issueModel.getIssueList();
   const [labelList] = await issueModel.getIssuesLableList();
   const [assigneeList] = await issueModel.getIssuesAssigneeList();
-
-  console.log('label', labelList);
 
   let labelIdx = 0;
   let assigneeIdx = 0;
@@ -42,7 +50,23 @@ export const getIssues = async (req, res, next) => {
   });
 
   // TODO : 여기에 필터조건 걸기
-  const filterdIssues = issuesWithLabelsAndMileStones.filter(i => i);
+  // TODO ::: 여기서 필터링하는 것보다 mysql 쿼리로 필터링을 거는게 좀 더 유연하게 될 듯..
+
+  const filterdIssues = issuesWithLabelsAndMileStones.filter(issue => {
+    if (author && issue.author !== author) {
+      return false;
+    }
+    if (assignee && !issue.assignees.some(a => a === assignee)) {
+      return false;
+    }
+    // if (label) {
+    //   if (Array.isArray(label) && label) {
+    //     return;
+    //   }
+    //   return;
+    // }
+    return true;
+  });
 
   // TODO : 해당 조건으로 검색하는 로직 구현
   // 검색 조건 + '검색어'로 검색이 가능해야함!

--- a/backend/routes/api/issues/issues.controller.js
+++ b/backend/routes/api/issues/issues.controller.js
@@ -1,13 +1,53 @@
+import { issueModel } from '@models';
 /**
  * GET /api/issues
  */
-export const getIssues = (req, res, next) => {
+export const getIssues = async (req, res, next) => {
   const { open, author, assignee, milestone, comment, label } = req.query;
+
+  const [issues] = await issueModel.getIssueList();
+  const [labelList] = await issueModel.getIssuesLableList();
+  const [assigneeList] = await issueModel.getIssuesAssigneeList();
+
+  console.log('label', labelList);
+
+  let labelIdx = 0;
+  let assigneeIdx = 0;
+
+  // TODO : 이 부분 서비스 코드로 분리하기
+  const issuesWithLabelsAndMileStones = issues.map(issue => {
+    const { no: issueNo } = issue;
+    const labels = [];
+    const assignees = [];
+    while (true) {
+      if (labelIdx >= labelList.length) break;
+      const label = labelList[labelIdx];
+      const { no, name, description, color } = label;
+
+      if (+label.issueNo !== +issueNo) break;
+      labels.push({ no, name, description, color });
+      labelIdx += 1;
+    }
+
+    while (true) {
+      if (assigneeIdx >= assigneeList.length) break;
+      const assignee = assigneeList[assigneeIdx];
+      const { userNo: no, nickname, image } = assignee;
+
+      if (+assignee.issueNo !== +issueNo) break;
+      assignees.push({ no, nickname, image });
+      assigneeIdx += 1;
+    }
+    return { ...issue, labels, assignees };
+  });
+
+  // TODO : 여기에 필터조건 걸기
+  const filterdIssues = issuesWithLabelsAndMileStones.filter(i => i);
 
   // TODO : 해당 조건으로 검색하는 로직 구현
   // 검색 조건 + '검색어'로 검색이 가능해야함!
 
-  res.json({ issues: [] });
+  res.json({ issues: filterdIssues });
 };
 
 /**


### PR DESCRIPTION
## 구현 사항

### 1.   GET /api/issues 

모든 이슈를 불러올 때 필요한 정보를 join해서 issues 배열을 생성하고, 각 이슈에 연결된 lables, assignees, comments를 추가하는 방식으로 구현했습니다.

lables, assignees, comments는 배열 값이라서 issue 테이블에 join을 통해 가져올 수가 없습니다.
(정확히 말해자면, 가져오는건 가능한데 데이터 정리가 쉽지않습니다.)

그래서 issues, lables, assignees, comments 각각 쿼리를 날려서 조회하고 각 배열을 ORDER BY issue_no 조건으로 정렬한 뒤 
issues 배열을 순회할 때, 나머지 세 배열(lables, assignees, comments)의 인덱스를 참조하여 issueNo을 비교하면서 인덱스를 증가시키는 방식으로 구현했습니다.

그러다보니 로직이 한눈에 보기 힘든점 양해부탁드려요..

o(n)으로 끝낼 수 있는 최선으로 구현했는데 더 좋은 방법 찾으면 대체하셔도 좋습니다.

해당 알고리즘이 얼추 맞게 돌아가는것 같긴한데 완벽하게 검증은 못했습니다. 아마 잘될거에요..

---

### 아래 그림에 나온 조건으로 필터링 하는 것은 모두 테스트해봤습니다.  (keyword로 검색하는 부분은 보류 상태입니다.)
 
- 하지만 데이터가 적다보니 아직 제가 예외처리하지 못한 부분이 있을 수도..

<img width=500 src="https://user-images.githubusercontent.com/61396464/97473869-d1bff200-198e-11eb-9347-b2699a917c87.png"/>




