### PR TITLE
[iOS-#60] github login present sequence fix

### DIFF
--- a/ios/IssueTracker/IssueTracker/Model/HTTPAgent.swift
+++ b/ios/IssueTracker/IssueTracker/Model/HTTPAgent.swift
@@ -42,7 +42,9 @@ class HTTPAgent: LoginProtocol {
                 if let json = try? JSONSerialization.jsonObject(with: data!, options: [])
                     as? [String: Any] {
                     if let token = json["access_token"] as? String {
-                        self.getUser(token: token, completion: nil)
+                        self.getUser(token: token, completion: { statusCode in
+                            NotificationCenter.default.post(name: Notification.googleLoginSuccess, object: self, userInfo: ["statusCode": statusCode])
+                        })
                     }
                 }
             }


### PR DESCRIPTION
## 유지보수 항목
- 깃허브 로그인 버튼을 눌렸을 경우, 로그인의 성공 유무와는 관련없이 다음 화면이 먼저 로드되는 현상이 있었다. 이 부분에 대해 로그인에 성공했을 때에만 NotificationCenter를 활용하여 다음 화면으로 전환되도록 구현했다.