### PR TITLE
[iOS-#84,#86] label edit, add VC, filter VC layout setting, issue VC layout fix

### DIFF
--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		14CC4F5606CBC1D30E2290A2 /* Pods_IssueTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B11756D279E0DA64222E52E5 /* Pods_IssueTracker.framework */; };
 		4C2787BB25500F6100E31035 /* SectionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2787BA25500F6100E31035 /* SectionItem.swift */; };
 		4C2787BF25500FD800E31035 /* ListCollectionViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2787BE25500FD800E31035 /* ListCollectionViewProtocol.swift */; };
+		4C44042C2551B07E0075AD9B /* Milestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C44042B2551B07E0075AD9B /* Milestone.swift */; };
+		4C4404342551BCBE0075AD9B /* MilestoneViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4404322551BCBE0075AD9B /* MilestoneViewCell.swift */; };
+		4C4404352551BCBE0075AD9B /* MilestoneViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4C4404332551BCBE0075AD9B /* MilestoneViewCell.xib */; };
 		4C7C11B8254E87CC008FA858 /* IssueDetailCommentViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7C11B6254E87CC008FA858 /* IssueDetailCommentViewCell.swift */; };
 		4C7C11B9254E87CC008FA858 /* IssueDetailCommentViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4C7C11B7254E87CC008FA858 /* IssueDetailCommentViewCell.xib */; };
 		4C7C11C3254EC6B9008FA858 /* IssueDetailHeaderReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7C11C1254EC6B8008FA858 /* IssueDetailHeaderReusableView.swift */; };
@@ -17,9 +20,6 @@
 		4CB6F8FD254D639300901E9D /* IssueDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB6F8FC254D639300901E9D /* IssueDetailViewController.swift */; };
 		4CD20476255141CD0001B987 /* IssueDetailBottomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD20475255141CD0001B987 /* IssueDetailBottomViewController.swift */; };
 		4CD2047925514E4C0001B987 /* CornerRoundedFloatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2047825514E4C0001B987 /* CornerRoundedFloatingView.swift */; };
-		4C44042C2551B07E0075AD9B /* Milestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C44042B2551B07E0075AD9B /* Milestone.swift */; };
-		4C4404342551BCBE0075AD9B /* MilestoneViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4404322551BCBE0075AD9B /* MilestoneViewCell.swift */; };
-		4C4404352551BCBE0075AD9B /* MilestoneViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4C4404332551BCBE0075AD9B /* MilestoneViewCell.xib */; };
 		4CD204882551A5230001B987 /* MilestoneViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD204872551A5230001B987 /* MilestoneViewController.swift */; };
 		C1048958255112230091668C /* IssueAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1048957255112230091668C /* IssueAddViewController.swift */; };
 		C104895B2551280C0091668C /* FilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C104895A2551280C0091668C /* FilterViewController.swift */; };
@@ -27,6 +27,7 @@
 		C104896F25518EC50091668C /* LabelCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C104896D25518EC50091668C /* LabelCollectionViewCell.swift */; };
 		C104897025518EC50091668C /* LabelCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C104896E25518EC50091668C /* LabelCollectionViewCell.xib */; };
 		C10489732551986B0091668C /* LabelDetailAndAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10489722551986B0091668C /* LabelDetailAndAddViewController.swift */; };
+		C1140D8325527C6F0096C11E /* DesignableClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1140D8225527C6F0096C11E /* DesignableClass.swift */; };
 		C117D89E2547C7CF0081DCD7 /* IssueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C117D89D2547C7CF0081DCD7 /* IssueViewController.swift */; };
 		C12542602547F44C00DE2BB8 /* IssueCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C125425F2547F44C00DE2BB8 /* IssueCollectionViewCell.swift */; };
 		C12542632548007500DE2BB8 /* UIExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12542622548007500DE2BB8 /* UIExtension.swift */; };
@@ -45,6 +46,9 @@
 		0AC642BD38CA333388D53582 /* Pods-IssueTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.debug.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.debug.xcconfig"; sourceTree = "<group>"; };
 		4C2787BA25500F6100E31035 /* SectionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionItem.swift; sourceTree = "<group>"; };
 		4C2787BE25500FD800E31035 /* ListCollectionViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCollectionViewProtocol.swift; sourceTree = "<group>"; };
+		4C44042B2551B07E0075AD9B /* Milestone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milestone.swift; sourceTree = "<group>"; };
+		4C4404322551BCBE0075AD9B /* MilestoneViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneViewCell.swift; sourceTree = "<group>"; };
+		4C4404332551BCBE0075AD9B /* MilestoneViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MilestoneViewCell.xib; sourceTree = "<group>"; };
 		4C7C11B6254E87CC008FA858 /* IssueDetailCommentViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailCommentViewCell.swift; sourceTree = "<group>"; };
 		4C7C11B7254E87CC008FA858 /* IssueDetailCommentViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueDetailCommentViewCell.xib; sourceTree = "<group>"; };
 		4C7C11C1254EC6B8008FA858 /* IssueDetailHeaderReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailHeaderReusableView.swift; sourceTree = "<group>"; };
@@ -52,9 +56,6 @@
 		4CB6F8FC254D639300901E9D /* IssueDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailViewController.swift; sourceTree = "<group>"; };
 		4CD20475255141CD0001B987 /* IssueDetailBottomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailBottomViewController.swift; sourceTree = "<group>"; };
 		4CD2047825514E4C0001B987 /* CornerRoundedFloatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRoundedFloatingView.swift; sourceTree = "<group>"; };
-		4C44042B2551B07E0075AD9B /* Milestone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milestone.swift; sourceTree = "<group>"; };
-		4C4404322551BCBE0075AD9B /* MilestoneViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneViewCell.swift; sourceTree = "<group>"; };
-		4C4404332551BCBE0075AD9B /* MilestoneViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MilestoneViewCell.xib; sourceTree = "<group>"; };
 		4CD204872551A5230001B987 /* MilestoneViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneViewController.swift; sourceTree = "<group>"; };
 		B11756D279E0DA64222E52E5 /* Pods_IssueTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IssueTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1048957255112230091668C /* IssueAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAddViewController.swift; sourceTree = "<group>"; };
@@ -63,6 +64,7 @@
 		C104896D25518EC50091668C /* LabelCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelCollectionViewCell.swift; sourceTree = "<group>"; };
 		C104896E25518EC50091668C /* LabelCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LabelCollectionViewCell.xib; sourceTree = "<group>"; };
 		C10489722551986B0091668C /* LabelDetailAndAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelDetailAndAddViewController.swift; sourceTree = "<group>"; };
+		C1140D8225527C6F0096C11E /* DesignableClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignableClass.swift; sourceTree = "<group>"; };
 		C117D89D2547C7CF0081DCD7 /* IssueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueViewController.swift; sourceTree = "<group>"; };
 		C125425F2547F44C00DE2BB8 /* IssueCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCollectionViewCell.swift; sourceTree = "<group>"; };
 		C12542622548007500DE2BB8 /* UIExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIExtension.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 		C117D8A62547C9300081DCD7 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				C1140D8225527C6F0096C11E /* DesignableClass.swift */,
 				C104896D25518EC50091668C /* LabelCollectionViewCell.swift */,
 				C104896E25518EC50091668C /* LabelCollectionViewCell.xib */,
 				C125425F2547F44C00DE2BB8 /* IssueCollectionViewCell.swift */,
@@ -332,6 +335,7 @@
 				4CD2047925514E4C0001B987 /* CornerRoundedFloatingView.swift in Sources */,
 				4C7C11C3254EC6B9008FA858 /* IssueDetailHeaderReusableView.swift in Sources */,
 				C196564A2546B9B6007DD55A /* SceneDelegate.swift in Sources */,
+				C1140D8325527C6F0096C11E /* DesignableClass.swift in Sources */,
 				4CD20476255141CD0001B987 /* IssueDetailBottomViewController.swift in Sources */,
 				4CD204882551A5230001B987 /* MilestoneViewController.swift in Sources */,
 				C104895B2551280C0091668C /* FilterViewController.swift in Sources */,

--- a/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -116,11 +116,6 @@
                                 <action selector="filterButton:" destination="J5c-pF-frK" id="6cJ-SA-qcL"/>
                             </connections>
                         </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" title="edit" id="nD9-zO-N4r">
-                            <connections>
-                                <action selector="issueEditButton:" destination="J5c-pF-frK" id="o9E-jQ-Oap"/>
-                            </connections>
-                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <segue destination="Zva-Qn-br1" kind="presentation" identifier="newIssueSegue" id="Pck-2y-p0S"/>

--- a/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Image references" minToolsVersion="12.0"/>
@@ -14,29 +14,29 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이슈 트래커" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S2P-iA-bQt">
-                                <rect key="frame" x="127" y="95" width="136" height="36"/>
+                                <rect key="frame" x="139" y="95" width="136" height="36"/>
                                 <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="아이디" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ybf-Sp-dFu">
-                                <rect key="frame" x="55.666666666666657" y="231" width="278.66666666666674" height="34"/>
+                                <rect key="frame" x="59" y="231" width="296" height="34"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="비밀번호" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gd7-8h-sNm">
-                                <rect key="frame" x="55.666666666666657" y="287" width="278.66666666666674" height="34"/>
+                                <rect key="frame" x="59" y="287" width="296" height="34"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ebc-9H-EKE">
-                                <rect key="frame" x="55.666666666666657" y="421" width="278.66666666666674" height="47"/>
+                                <rect key="frame" x="59" y="421" width="296" height="50"/>
                                 <color key="backgroundColor" systemColor="systemGrayColor"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
                                 <state key="normal" title="Sign in with Github">
@@ -47,11 +47,11 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OCz-rS-N63">
-                                <rect key="frame" x="55.666666666666657" y="488" width="278.66666666666674" height="47.333333333333371"/>
-                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                <rect key="frame" x="59" y="491" width="296" height="50"/>
+                                <color key="backgroundColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
                                 <state key="normal" title="Sign in with Apple">
-                                    <color key="titleColor" systemColor="labelColor"/>
+                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
                                 </state>
                                 <connections>
                                     <action selector="appleLogin:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Bf2-or-2FC"/>
@@ -59,7 +59,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SnD-5c-mMS">
-                                <rect key="frame" x="175.66666666666666" y="348" width="39" height="30"/>
+                                <rect key="frame" x="187.5" y="348" width="39" height="30"/>
                                 <state key="normal" title="로그인"/>
                                 <connections>
                                     <action selector="loginButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LRZ-ot-E0Z"/>
@@ -104,7 +104,7 @@
             <objects>
                 <viewController modalPresentationStyle="fullScreen" id="J5c-pF-frK" customClass="IssueViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tHu-VI-KCo">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="4Ph-jJ-jeH"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -124,12 +124,8 @@
                     </navigationItem>
                     <connections>
                         <segue destination="Zva-Qn-br1" kind="presentation" identifier="newIssueSegue" id="Pck-2y-p0S"/>
-
-                        <segue destination="uYF-Zc-Jxh" kind="show" identifier="presentIssueEdit" id="Nuc-32-9lj"/>
                         <segue destination="oiX-ag-8Nt" kind="show" identifier="issueDetailSegue" id="zdS-aN-lOz"/>
-
                         <segue destination="cU1-Sd-kyi" kind="presentation" identifier="filterSegue" id="Pdg-FI-22b"/>
-
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="c3e-rB-1a3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -141,7 +137,7 @@
             <objects>
                 <viewController id="haK-TN-pmh" customClass="LabelViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="3NO-b0-t32">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="2NZ-zK-WfJ"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -162,22 +158,223 @@
             <objects>
                 <viewController id="vbQ-aR-pab" customClass="LabelDetailAndAddViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="gd1-0g-Xfk">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bi4-fc-3ll" customClass="RoundView" customModule="IssueTracker" customModuleProvider="target">
+                                <rect key="frame" x="20" y="291" width="374" height="379"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gMm-k5-EmU">
+                                        <rect key="frame" x="20" y="22" width="20" height="20"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="20" id="RZx-7E-0tN"/>
+                                            <constraint firstAttribute="height" constant="24.5" id="xny-hW-ceR"/>
+                                        </constraints>
+                                        <color key="tintColor" systemColor="labelColor"/>
+                                        <state key="normal" backgroundImage="xmark" catalog="system"/>
+                                        <connections>
+                                            <action selector="closeButton:" destination="vbQ-aR-pab" eventType="touchUpInside" id="4OF-ac-b0T"/>
+                                        </connections>
+                                    </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gU8-pb-TDb">
+                                        <rect key="frame" x="0.0" y="54" width="374" height="2"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="2" id="wOw-Di-Tzp"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ddy-hF-Huk">
+                                        <rect key="frame" x="32" y="83" width="30" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S9r-z8-i4z">
+                                        <rect key="frame" x="32" y="115" width="309" height="1"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="T3u-Ef-cWI"/>
+                                        </constraints>
+                                    </view>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="R03-Aq-F41">
+                                        <rect key="frame" x="83" y="70" width="258" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Smj-Lh-gca">
+                                        <rect key="frame" x="33" y="160" width="30" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QVI-ky-h4n">
+                                        <rect key="frame" x="33" y="192" width="309" height="1"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="G3F-hS-2eI"/>
+                                        </constraints>
+                                    </view>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="d2V-KT-4Ad">
+                                        <rect key="frame" x="84" y="147" width="258" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="색상" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MIv-wn-aFm">
+                                        <rect key="frame" x="33" y="237" width="30" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L9V-sS-FV7">
+                                        <rect key="frame" x="33" y="269" width="309" height="1"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="1" id="F86-Fj-jdk"/>
+                                            <constraint firstAttribute="height" constant="1" id="HA7-HV-spG"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e8z-BY-ZXa" customClass="RoundView" customModule="IssueTracker" customModuleProvider="target">
+                                        <rect key="frame" x="206" y="231" width="81" height="32"/>
+                                        <color key="backgroundColor" systemColor="systemPinkColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="e8z-BY-ZXa" secondAttribute="height" multiplier="81:32" id="ghQ-2P-MNp"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="12"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tLF-qd-6N3">
+                                        <rect key="frame" x="311" y="232" width="30" height="30"/>
+                                        <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="tLF-qd-6N3" secondAttribute="height" multiplier="1:1" id="WKe-8m-rzN"/>
+                                        </constraints>
+                                        <color key="tintColor" systemColor="labelColor"/>
+                                        <state key="normal">
+                                            <imageReference key="image" image="arrow.clockwise" catalog="system" symbolScale="small"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="0.0"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fCf-LW-68K">
+                                        <rect key="frame" x="116" y="231" width="66" height="32"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="66" id="2XA-ni-s33"/>
+                                            <constraint firstAttribute="height" constant="32" id="aIM-qj-iJf"/>
+                                        </constraints>
+                                        <state key="normal" title="#FF5D5D">
+                                            <color key="titleColor" systemColor="labelColor"/>
+                                        </state>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jpx-9k-Q2S">
+                                        <rect key="frame" x="22" y="331" width="39" height="30"/>
+                                        <state key="normal" title="초기화">
+                                            <color key="titleColor" systemColor="systemGray2Color"/>
+                                        </state>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="K6B-Az-20u" customClass="RoundButton" customModule="IssueTracker" customModuleProvider="target">
+                                        <rect key="frame" x="293" y="327" width="61" height="34"/>
+                                        <color key="backgroundColor" systemColor="labelColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="K6B-Az-20u" secondAttribute="height" multiplier="61:34" id="6ng-0j-QSy"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="61" id="kGS-rW-2Fx"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                        <state key="normal" title="저장">
+                                            <color key="titleColor" systemColor="systemBackgroundColor"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="5"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="R03-Aq-F41" firstAttribute="width" secondItem="bi4-fc-3ll" secondAttribute="width" multiplier="0.68984" id="1Qa-9N-6Ho"/>
+                                    <constraint firstItem="gU8-pb-TDb" firstAttribute="top" secondItem="gMm-k5-EmU" secondAttribute="bottom" constant="9.5" id="3qm-Jj-9LD"/>
+                                    <constraint firstAttribute="trailing" secondItem="gU8-pb-TDb" secondAttribute="trailing" id="4o5-UO-bDn"/>
+                                    <constraint firstItem="fCf-LW-68K" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="MIv-wn-aFm" secondAttribute="trailing" constant="8" symbolic="YES" id="5Aa-Xv-TL3"/>
+                                    <constraint firstAttribute="trailing" secondItem="K6B-Az-20u" secondAttribute="trailing" constant="20" symbolic="YES" id="5X6-oq-LEC"/>
+                                    <constraint firstItem="gMm-k5-EmU" firstAttribute="top" secondItem="bi4-fc-3ll" secondAttribute="top" constant="20" id="6Zv-eX-WWf"/>
+                                    <constraint firstAttribute="height" constant="379" id="8J4-YS-bHy"/>
+                                    <constraint firstItem="S9r-z8-i4z" firstAttribute="top" secondItem="ddy-hF-Huk" secondAttribute="bottom" constant="11" id="8MF-6c-pRT"/>
+                                    <constraint firstItem="K6B-Az-20u" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Jpx-9k-Q2S" secondAttribute="trailing" constant="8" symbolic="YES" id="AY1-c4-krX"/>
+                                    <constraint firstItem="L9V-sS-FV7" firstAttribute="top" secondItem="MIv-wn-aFm" secondAttribute="bottom" constant="11" id="D29-M1-7Fj"/>
+                                    <constraint firstItem="R03-Aq-F41" firstAttribute="bottom" secondItem="ddy-hF-Huk" secondAttribute="bottom" id="DQo-Sq-gnc"/>
+                                    <constraint firstItem="MIv-wn-aFm" firstAttribute="top" secondItem="QVI-ky-h4n" secondAttribute="bottom" constant="44" id="DfP-l7-l39"/>
+                                    <constraint firstItem="R03-Aq-F41" firstAttribute="leading" secondItem="ddy-hF-Huk" secondAttribute="trailing" constant="21" id="GIJ-9I-r7f"/>
+                                    <constraint firstItem="R03-Aq-F41" firstAttribute="height" secondItem="bi4-fc-3ll" secondAttribute="height" multiplier="0.0897098" id="Ged-A6-qOS"/>
+                                    <constraint firstItem="Smj-Lh-gca" firstAttribute="leading" secondItem="bi4-fc-3ll" secondAttribute="leading" constant="33" id="Ll9-tx-hMC"/>
+                                    <constraint firstItem="Smj-Lh-gca" firstAttribute="top" secondItem="bi4-fc-3ll" secondAttribute="top" constant="160" id="PE4-y4-mha"/>
+                                    <constraint firstItem="gU8-pb-TDb" firstAttribute="leading" secondItem="bi4-fc-3ll" secondAttribute="leading" id="Pfq-Ym-hlD"/>
+                                    <constraint firstItem="tLF-qd-6N3" firstAttribute="width" secondItem="bi4-fc-3ll" secondAttribute="width" multiplier="0.0802139" id="RKj-Bg-1pC"/>
+                                    <constraint firstItem="ddy-hF-Huk" firstAttribute="top" secondItem="gU8-pb-TDb" secondAttribute="bottom" constant="27" id="RMk-wI-PLn"/>
+                                    <constraint firstItem="fCf-LW-68K" firstAttribute="centerY" secondItem="e8z-BY-ZXa" secondAttribute="centerY" id="S4f-5W-xx0"/>
+                                    <constraint firstItem="QVI-ky-h4n" firstAttribute="top" secondItem="Smj-Lh-gca" secondAttribute="bottom" constant="11" id="T0v-sH-H8E"/>
+                                    <constraint firstItem="d2V-KT-4Ad" firstAttribute="leading" secondItem="Smj-Lh-gca" secondAttribute="trailing" constant="21" id="T7g-Dj-DlB"/>
+                                    <constraint firstItem="tLF-qd-6N3" firstAttribute="leading" secondItem="e8z-BY-ZXa" secondAttribute="trailing" constant="24" id="T8e-OO-Tk8"/>
+                                    <constraint firstAttribute="trailing" secondItem="QVI-ky-h4n" secondAttribute="trailing" constant="32" id="TBb-qR-hbl"/>
+                                    <constraint firstItem="MIv-wn-aFm" firstAttribute="leading" secondItem="bi4-fc-3ll" secondAttribute="leading" constant="33" id="Tug-PO-YCl"/>
+                                    <constraint firstItem="S9r-z8-i4z" firstAttribute="leading" secondItem="bi4-fc-3ll" secondAttribute="leading" constant="32" id="UEZ-G3-2QF"/>
+                                    <constraint firstItem="e8z-BY-ZXa" firstAttribute="width" secondItem="bi4-fc-3ll" secondAttribute="width" multiplier="0.216578" id="Uhy-eh-Mwb"/>
+                                    <constraint firstItem="d2V-KT-4Ad" firstAttribute="bottom" secondItem="Smj-Lh-gca" secondAttribute="bottom" id="W9P-z1-zkG"/>
+                                    <constraint firstItem="gMm-k5-EmU" firstAttribute="leading" secondItem="bi4-fc-3ll" secondAttribute="leading" constant="20" id="dIt-QS-74j"/>
+                                    <constraint firstItem="ddy-hF-Huk" firstAttribute="leading" secondItem="bi4-fc-3ll" secondAttribute="leading" constant="32" id="ew7-Yv-aTi"/>
+                                    <constraint firstItem="Jpx-9k-Q2S" firstAttribute="leading" secondItem="bi4-fc-3ll" secondAttribute="leading" constant="22" id="hPQ-4X-OOg"/>
+                                    <constraint firstAttribute="trailing" secondItem="S9r-z8-i4z" secondAttribute="trailing" constant="33" id="kgV-iA-IMA"/>
+                                    <constraint firstItem="QVI-ky-h4n" firstAttribute="leading" secondItem="bi4-fc-3ll" secondAttribute="leading" constant="33" id="lME-rQ-v2l"/>
+                                    <constraint firstItem="L9V-sS-FV7" firstAttribute="top" secondItem="tLF-qd-6N3" secondAttribute="bottom" constant="7" id="mrE-ld-miq"/>
+                                    <constraint firstAttribute="bottom" secondItem="Jpx-9k-Q2S" secondAttribute="bottom" constant="18" id="nKo-nC-6UR"/>
+                                    <constraint firstItem="d2V-KT-4Ad" firstAttribute="width" secondItem="bi4-fc-3ll" secondAttribute="width" multiplier="0.68984" id="pBZ-1l-ygv"/>
+                                    <constraint firstAttribute="trailing" secondItem="tLF-qd-6N3" secondAttribute="trailing" constant="33" id="rm3-lh-Z3r"/>
+                                    <constraint firstItem="d2V-KT-4Ad" firstAttribute="height" secondItem="bi4-fc-3ll" secondAttribute="height" multiplier="0.0897098" id="sma-KU-dAa"/>
+                                    <constraint firstItem="e8z-BY-ZXa" firstAttribute="leading" secondItem="fCf-LW-68K" secondAttribute="trailing" constant="24" id="v0g-Uq-qwJ"/>
+                                    <constraint firstItem="L9V-sS-FV7" firstAttribute="leading" secondItem="bi4-fc-3ll" secondAttribute="leading" constant="33" id="y2T-Wb-bfx"/>
+                                    <constraint firstAttribute="bottom" secondItem="K6B-Az-20u" secondAttribute="bottom" constant="18" id="y8C-or-2q2"/>
+                                    <constraint firstAttribute="trailing" secondItem="L9V-sS-FV7" secondAttribute="trailing" constant="32" id="yd7-8o-JBx"/>
+                                    <constraint firstItem="e8z-BY-ZXa" firstAttribute="centerY" secondItem="tLF-qd-6N3" secondAttribute="centerY" id="yfV-Oe-GPv"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="12"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="M4o-Vi-M4k"/>
                         <color key="backgroundColor" red="0.32735589378238339" green="0.32735589378238339" blue="0.32735589378238339" alpha="0.5" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="bi4-fc-3ll" firstAttribute="height" secondItem="gd1-0g-Xfk" secondAttribute="height" multiplier="0.422991" id="1hI-aE-h3T"/>
+                            <constraint firstItem="bi4-fc-3ll" firstAttribute="top" secondItem="M4o-Vi-M4k" secondAttribute="top" constant="247" id="Axw-q4-q3J"/>
+                            <constraint firstItem="M4o-Vi-M4k" firstAttribute="trailing" secondItem="bi4-fc-3ll" secondAttribute="trailing" constant="20" id="QhG-rU-eXE"/>
+                            <constraint firstItem="bi4-fc-3ll" firstAttribute="leading" secondItem="M4o-Vi-M4k" secondAttribute="leading" constant="20" id="Yqg-xd-jmB"/>
+                        </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="1hI-aE-h3T"/>
+                            </mask>
+                        </variation>
                     </view>
+                    <connections>
+                        <outlet property="colorPickerView" destination="bi4-fc-3ll" id="fT1-n4-QHy"/>
+                        <outlet property="colorPickerViewTopConstraint" destination="Axw-q4-q3J" id="Dth-Fy-2vq"/>
+                        <outlet property="randomColorPickButton" destination="tLF-qd-6N3" id="321-d7-Er2"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Pan-yN-WSZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3788" y="116"/>
+            <point key="canvasLocation" x="3786.9565217391309" y="115.84821428571428"/>
         </scene>
         <!--Filter View Controller-->
         <scene sceneID="zGp-Tu-lMb">
             <objects>
                 <viewController id="cU1-Sd-kyi" customClass="FilterViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="uDZ-aP-pJH">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OSU-i3-inM">
@@ -189,7 +386,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lTC-YV-G1w">
-                                <rect key="frame" x="337" y="20" width="37" height="30"/>
+                                <rect key="frame" x="361" y="20" width="37" height="30"/>
                                 <state key="normal" title="Done"/>
                                 <connections>
                                     <action selector="cancelButton:" destination="Zva-Qn-br1" eventType="touchUpInside" id="tVs-GR-lrq"/>
@@ -197,14 +394,14 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DvQ-qv-BJD">
-                                <rect key="frame" x="16" y="58" width="358" height="1"/>
+                                <rect key="frame" x="20" y="58" width="374" height="1"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="uMb-ct-VNu"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="필터 선택" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="enn-24-4e5">
-                                <rect key="frame" x="15.999999999999993" y="67" width="110.33333333333331" height="36"/>
+                                <rect key="frame" x="16" y="67" width="110.5" height="36"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -240,18 +437,18 @@
             <objects>
                 <viewController id="Zva-Qn-br1" customClass="IssueAddViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ito-Fd-FbK">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="kXA-2p-Wog">
-                                <rect key="frame" x="31" y="170" width="328" height="32"/>
+                                <rect key="frame" x="31" y="170" width="352" height="32"/>
                                 <segments>
                                     <segment title="마크다운"/>
                                     <segment title="미리보기"/>
                                 </segments>
                             </segmentedControl>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P1F-ef-FVK">
-                                <rect key="frame" x="31" y="20" width="48" height="30"/>
+                                <rect key="frame" x="55" y="20" width="48" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="cNd-vT-qqB"/>
                                 </constraints>
@@ -266,21 +463,21 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s65-iS-ox3">
-                                <rect key="frame" x="16" y="58" width="358" height="1"/>
+                                <rect key="frame" x="20" y="58" width="374" height="1"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="exb-Zz-CxE"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MTW-Lk-1NY">
-                                <rect key="frame" x="31" y="148" width="328" height="1"/>
+                                <rect key="frame" x="35" y="148" width="344" height="1"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="hl4-nw-seI"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="새 이슈" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JTK-R4-kv3">
-                                <rect key="frame" x="16" y="67" width="84.333333333333329" height="36"/>
+                                <rect key="frame" x="16" y="67" width="84.5" height="36"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -292,19 +489,19 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zEx-b5-Sf5">
-                                <rect key="frame" x="65" y="113.33333333333333" width="291.33333333333331" height="35.333333333333329"/>
+                                <rect key="frame" x="65" y="112" width="309" height="38"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="코멘트는 여기다 작성하세요" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="QcY-m7-CAu">
-                                <rect key="frame" x="31" y="209" width="328" height="244"/>
+                                <rect key="frame" x="31" y="209" width="352" height="260"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="systemGray2Color"/>
                                 <fontDescription key="fontDescription" name=".AppleSDGothicNeoI-Regular" family=".AppleKoreanFont" pointSize="15"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2JB-J3-QCc">
-                                <rect key="frame" x="342.66666666666669" y="69.333333333333329" width="31.333333333333314" height="31.333333333333329"/>
+                                <rect key="frame" x="365" y="68.5" width="33" height="33"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="2JB-J3-QCc" secondAttribute="height" multiplier="1:1" id="MRP-gy-qDB"/>
                                 </constraints>
@@ -366,7 +563,7 @@
             <objects>
                 <viewController hidesBottomBarWhenPushed="YES" id="oiX-ag-8Nt" customClass="IssueDetailViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Hr8-1g-leQ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="oyJ-gc-mJa"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -387,18 +584,18 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Lh5-Dg-XeN" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3576.8000000000002" y="875.61576354679812"/>
+            <point key="canvasLocation" x="4609" y="116"/>
         </scene>
         <!--Issue Detail Bottom View Controller-->
         <scene sceneID="Eu2-0p-PZB">
             <objects>
                 <viewController storyboardIdentifier="issueDetailBottomVC" id="Fly-Wc-ZSU" customClass="IssueDetailBottomViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="dWf-My-YGf" customClass="CornerRoundedFloatingView" customModule="IssueTracker" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L14-b5-iZc">
-                                <rect key="frame" x="167.66666666666666" y="10" width="40" height="6"/>
+                                <rect key="frame" x="187" y="10" width="40" height="6"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="6" id="BCF-2C-BJi"/>
@@ -411,24 +608,24 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sJZ-Go-YBs" customClass="CornerRoundedFloatingView" customModule="IssueTracker" customModuleProvider="target">
-                                <rect key="frame" x="255" y="26" width="100" height="50"/>
+                                <rect key="frame" x="294" y="26" width="100" height="50"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yi8-js-74W">
-                                        <rect key="frame" x="49.666666666666686" y="0.0" width="1" height="50"/>
+                                        <rect key="frame" x="49.5" y="0.0" width="1" height="50"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="1" id="3G7-eZ-ahx"/>
                                         </constraints>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mYp-fI-C25">
-                                        <rect key="frame" x="0.0" y="0.0" width="49.666666666666664" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="49.5" height="50"/>
                                         <state key="normal" image="chevron.up" catalog="system"/>
                                         <connections>
                                             <action selector="upButtonAction:" destination="Fly-Wc-ZSU" eventType="touchUpInside" id="XKC-pK-bOJ"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IEv-dD-ZFu">
-                                        <rect key="frame" x="50.666666666666686" y="0.0" width="49.333333333333343" height="50"/>
+                                        <rect key="frame" x="50.5" y="0.0" width="49.5" height="50"/>
                                         <state key="normal" image="chevron.down" catalog="system"/>
                                         <connections>
                                             <action selector="downButtonAction:" destination="Fly-Wc-ZSU" eventType="touchUpInside" id="2hP-5C-Lsv"/>
@@ -453,10 +650,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ewl-yj-YiC" customClass="CornerRoundedFloatingView" customModule="IssueTracker" customModuleProvider="target">
-                                <rect key="frame" x="20" y="26" width="215" height="50"/>
+                                <rect key="frame" x="20" y="26" width="254" height="50"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9IH-Gh-YFE">
-                                        <rect key="frame" x="0.0" y="0.0" width="215" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="254" height="50"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                         <state key="normal" title="Comment"/>
                                         <connections>
@@ -501,7 +698,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="goC-le-QKn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4349.6000000000004" y="875.61576354679812"/>
+            <point key="canvasLocation" x="4608" y="802"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="JrQ-xi-R2Y">
@@ -531,7 +728,7 @@
                     <tabBarItem key="tabBarItem" title="이슈" image="1.circle.fill" catalog="system" id="0XE-YW-Cdo"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="974-nL-UCP">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="108"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="108"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -550,7 +747,7 @@
                     <tabBarItem key="tabBarItem" title="레이블" image="2.circle.fill" catalog="system" id="qoH-7i-c8Q"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="P02-OH-w9P">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="108"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="108"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -567,7 +764,7 @@
             <objects>
                 <viewController id="MPA-we-Xh4" customClass="MilestoneViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ReH-jp-1zl">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="ngz-iU-hsb"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -589,7 +786,7 @@
             <objects>
                 <viewController id="1m3-1x-TNp" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="mWh-H4-BBK">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="jkZ-73-04w"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -606,7 +803,7 @@
                     <tabBarItem key="tabBarItem" title="마일스톤" image="3.circle.fill" catalog="system" id="DO1-wC-JGB"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="CKH-p4-Lci">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="108"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="108"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -619,17 +816,21 @@
             <point key="canvasLocation" x="2242" y="802"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="K6B-Az-20u">
+            <size key="intrinsicContentSize" width="32" height="34"/>
+        </designable>
+    </designables>
     <resources>
-
-        <image name="chevron.backward" catalog="system" width="96" height="128"/>
-        <image name="chevron.down" catalog="system" width="128" height="72"/>
-        <image name="chevron.up" catalog="system" width="128" height="72"/>
-
         <image name="1.circle.fill" catalog="system" width="128" height="121"/>
         <image name="2.circle.fill" catalog="system" width="128" height="121"/>
         <image name="3.circle.fill" catalog="system" width="128" height="121"/>
+        <image name="arrow.clockwise" catalog="system" width="115" height="128"/>
         <image name="baseline_queue_black_48pt" width="48" height="48"/>
-
+        <image name="chevron.backward" catalog="system" width="96" height="128"/>
+        <image name="chevron.down" catalog="system" width="128" height="72"/>
+        <image name="chevron.up" catalog="system" width="128" height="72"/>
+        <image name="xmark" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
@@ -650,6 +851,9 @@
         </systemColor>
         <systemColor name="systemGroupedBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/ios/IssueTracker/IssueTracker/Controller/FilterViewController.swift
+++ b/ios/IssueTracker/IssueTracker/Controller/FilterViewController.swift
@@ -16,6 +16,7 @@ class FilterViewController: UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        
     }
 
     @IBAction func cancelButton(_ sender: UIButton) {

--- a/ios/IssueTracker/IssueTracker/Controller/FilterViewController.swift
+++ b/ios/IssueTracker/IssueTracker/Controller/FilterViewController.swift
@@ -10,13 +10,38 @@ import UIKit
 
 class FilterViewController: UIViewController {
     @IBOutlet weak var titleLabel: UILabel!
+    private var dataSource: UICollectionViewDiffableDataSource<Int, Item>! = nil
+    private var collectionView: UICollectionView! = nil
+    private var sectionTitles: [Item] = [
+        Item(title: "다음 중에 조건을 고르세요"),
+        Item(title: "세부 조건")
+    ]
+    private var lists: [[Item]] = [
+        [
+            Item(title: "열린 이슈들"),
+            Item(title: "내가 작성한 이슈들"),
+            Item(title: "나한테 할당된 이슈들"),
+            Item(title: "내가 댓글을 남긴 이슈들"),
+            Item(title: "닫힌 이슈들")
+        ],
+        [
+            Item(title: "작성자"),
+            Item(title: "레이블"),
+            Item(title: "마일스톤"),
+            Item(title: "담당자")
+        ]
+    ]
+    
+    private struct Item: Hashable {
+        let title: String?
+        private let identifier = UUID()
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
         
+        configureHierarchy()
+        configureDataSource()
     }
 
     @IBAction func cancelButton(_ sender: UIButton) {
@@ -25,5 +50,97 @@ class FilterViewController: UIViewController {
     
     @IBAction func doneButton(_ sender: UIButton) {
 //        dismiss(animated: true, completion: nil)
+    }
+}
+extension FilterViewController {
+    func configureHierarchy() {
+        collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: createLayout())
+        collectionView.delegate = self
+        collectionView.allowsMultipleSelection = true
+        view.addSubview(collectionView)
+        
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor, constant: 10),
+            collectionView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+    }
+    
+    func configureDataSource() {
+        let cellHeaderRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, Item> { (cell, _, item) in
+            var content = cell.defaultContentConfiguration()
+            content.text = item.title
+            cell.contentConfiguration = content
+        }
+        
+        let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, Item> { (cell, indexPath, item) in
+            var content = cell.defaultContentConfiguration()
+            content.text = item.title
+            cell.contentConfiguration = content
+            if indexPath.section == 1 {
+                cell.accessories = [.disclosureIndicator()]
+            } else {
+                cell.accessories = []
+            }
+            cell.backgroundConfiguration?.backgroundColor = .systemBackground
+        }
+        
+        dataSource = UICollectionViewDiffableDataSource<Int, Item>(collectionView: collectionView) { (collectionView: UICollectionView, indexPath: IndexPath, item: Item) -> UICollectionViewCell? in
+            if indexPath.item == 0 {
+                return collectionView.dequeueConfiguredReusableCell(using: cellHeaderRegistration, for: indexPath, item: item)
+            } else {
+                return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: item)
+            }
+        }
+        
+        updateList()
+    }
+    
+    func createLayout() -> UICollectionViewLayout {
+        return UICollectionViewCompositionalLayout { _, layoutEnvironment in
+            var config = UICollectionLayoutListConfiguration(appearance: .grouped)
+            config.headerMode = .firstItemInSection
+            return NSCollectionLayoutSection.list(using: config, layoutEnvironment: layoutEnvironment)
+        }
+    }
+    
+    private func updateList() {
+        // initial data
+        var snapshot = NSDiffableDataSourceSnapshot<Int, Item>()
+        let sections = Array(0..<2)
+        snapshot.appendSections(sections)
+        dataSource.apply(snapshot, animatingDifferences: false)
+        for section in sections {
+            var sectionSnapshot = NSDiffableDataSourceSectionSnapshot<Item>()
+            let headerItem = sectionTitles[section]
+            sectionSnapshot.append([headerItem])
+            let items = lists[section]
+            sectionSnapshot.append(items, to: headerItem)
+            sectionSnapshot.expand([headerItem])
+            dataSource.apply(sectionSnapshot, to: section)
+        }
+    }
+}
+extension FilterViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? UICollectionViewListCell else {
+            return
+        }
+        
+        if indexPath.section == 0 {
+            cell.accessories = [.checkmark(displayed: .always, options: .init())]
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? UICollectionViewListCell else {
+            return
+        }
+        
+        if indexPath.section == 0 {
+            cell.accessories = []
+        }
     }
 }

--- a/ios/IssueTracker/IssueTracker/Controller/LabelDetailAndAddViewController.swift
+++ b/ios/IssueTracker/IssueTracker/Controller/LabelDetailAndAddViewController.swift
@@ -9,33 +9,34 @@
 import UIKit
 
 class LabelDetailAndAddViewController: UIViewController {
-    private let alertView: UIView = {
-        let alertView = UIView()
-        alertView.backgroundColor = .white
-        alertView.layer.masksToBounds = true
-        alertView.layer.cornerRadius = 12
-        
-        return alertView
-    }()
-
+    @IBOutlet weak var colorPickerView: RoundView!
+    @IBOutlet weak var colorPickerViewTopConstraint: NSLayoutConstraint!
+    @IBOutlet weak var randomColorPickButton: UIButton!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        randomColorPickButton.layer.cornerRadius = randomColorPickButton.frame.width/2.0-1
+        colorPickerViewTopConstraint.constant = -100-colorPickerView.frame.height
+        colorPickerView.layoutIfNeeded()
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        self.view.addSubview(alertView)
-        alertView.frame = CGRect(x: 20, y: -300, width: self.view.frame.width-40, height: 300)
-        
-        let titleLabel = UILabel(frame: CGRect(x: 0, y: 0, width: alertView.frame.width, height: 80))
-        titleLabel.text = "hi, my name is KIBEOM"
-        titleLabel.textAlignment = .center
-        alertView.addSubview(titleLabel)
-        
         UIView.animate(withDuration: 0.25, animations: {
-            self.alertView.center = self.view.center
+            self.colorPickerView.center = self.view.center
         })
+    }
+    
+    @IBAction func closeButton(_ sender: UIButton) {
+        UIView.animate(withDuration: 0.25, animations: {
+            self.colorPickerView.center.y = -100-self.colorPickerView.frame.height
+        }, completion: { [weak self] done in
+            if done {
+                self?.dismiss(animated: false, completion: nil)
+            }
+        })
+        
     }
 }

--- a/ios/IssueTracker/IssueTracker/Controller/LabelViewController.swift
+++ b/ios/IssueTracker/IssueTracker/Controller/LabelViewController.swift
@@ -43,7 +43,8 @@ extension LabelViewController {
         
         collectionView.delegate = self
         collectionView.allowsMultipleSelection = true
-        collectionView.register(UINib(nibName: "LabelCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "LabelCollectionViewCell")
+        collectionView.register(UINib(nibName: "LabelCollectionViewCell", bundle: nil),
+                                forCellWithReuseIdentifier: "LabelCollectionViewCell")
     }
     
     func configureDataSource() {

--- a/ios/IssueTracker/IssueTracker/View/DesignableClass.swift
+++ b/ios/IssueTracker/IssueTracker/View/DesignableClass.swift
@@ -1,0 +1,25 @@
+//
+//  ColorPickerView.swift
+//  IssueTracker
+//
+//  Created by 남기범 on 2020/11/04.
+//  Copyright © 2020 남기범. All rights reserved.
+//
+
+import UIKit
+
+@IBDesignable
+class RoundView: UIView {
+    @IBInspectable var cornerRadius: CGFloat {
+        get { return layer.cornerRadius }
+        set { layer.cornerRadius = newValue }
+    }
+}
+
+@IBDesignable
+class RoundButton: UIButton {
+    @IBInspectable var cornerRadius: CGFloat {
+        get { return layer.cornerRadius }
+        set { layer.cornerRadius = newValue }
+    }
+}

--- a/ios/IssueTracker/IssueTracker/View/IssueCollectionViewCell.swift
+++ b/ios/IssueTracker/IssueTracker/View/IssueCollectionViewCell.swift
@@ -8,13 +8,7 @@
 
 import UIKit
 
-class IssueCollectionViewCell: UICollectionViewListCell {
-    let view: UIView = {
-        let view = UIView()
-        view.backgroundColor = UIColor.systemGray6
-        return view
-    }()
-    
+class IssueCollectionViewCell: UICollectionViewListCell {    
     let issueTitle: UILabel = {
         let label = UILabel()
         label.text = "레이블 목록 보기 구현"
@@ -68,34 +62,34 @@ class IssueCollectionViewCell: UICollectionViewListCell {
     }
     
     private func setupIssueTitle() {
-        view.addSubview(issueTitle)
+        contentView.addSubview(issueTitle)
         issueTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            issueTitle.topAnchor.constraint(equalTo: view.topAnchor, constant: 10),
-            issueTitle.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.25),
-            issueTitle.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15),
-            issueTitle.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.6)
+            issueTitle.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
+            issueTitle.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.25),
+            issueTitle.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 15),
+            issueTitle.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.6)
         ])
     }
     
     private func setupIssueDescription() {
-        view.addSubview(issueDescription)
+        contentView.addSubview(issueDescription)
         issueDescription.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             issueDescription.topAnchor.constraint(equalTo: issueTitle.bottomAnchor),
-            issueDescription.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.6),
+            issueDescription.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.6),
             issueDescription.leadingAnchor.constraint(equalTo: issueTitle.leadingAnchor),
             issueDescription.widthAnchor.constraint(equalTo: issueTitle.widthAnchor)
         ])
     }
     
     private func setupMilestone() {
-        view.addSubview(milestone)
+        contentView.addSubview(milestone)
         milestone.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            milestone.topAnchor.constraint(equalTo: view.topAnchor, constant: 10),
+            milestone.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
             milestone.heightAnchor.constraint(equalToConstant: milestone.intrinsicContentSize.height + 5),
-            milestone.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
+            milestone.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10),
             milestone.widthAnchor.constraint(equalToConstant: milestone.intrinsicContentSize.width + 20),
             milestone.leadingAnchor.constraint(greaterThanOrEqualTo: issueTitle.trailingAnchor, constant: 1)
         ])
@@ -105,12 +99,12 @@ class IssueCollectionViewCell: UICollectionViewListCell {
     }
     
     private func setupLabel() {
-        view.addSubview(label)
+        contentView.addSubview(label)
         label.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             label.topAnchor.constraint(equalTo: milestone.bottomAnchor, constant: 3),
             label.heightAnchor.constraint(equalToConstant: label.intrinsicContentSize.height + 5),
-            label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
+            label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10),
             label.widthAnchor.constraint(equalToConstant: label.intrinsicContentSize.width + 20)
         ])
         label.backgroundColor = .systemPink
@@ -119,16 +113,7 @@ class IssueCollectionViewCell: UICollectionViewListCell {
     }
     
     func setupBaseView(inset: CGFloat) {
-        addSubview(view)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            view.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
-            view.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: inset),
-            view.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: inset),
-            separatorLayoutGuide.leadingAnchor.constraint(equalTo: leadingAnchor)
-        ])
-        view.backgroundColor = UIColor.systemBackground
+        contentView.backgroundColor = UIColor.systemBackground
     }
     
     func setupViewsIfNeeded() {

--- a/ios/IssueTracker/IssueTracker/View/LabelCollectionViewCell.xib
+++ b/ios/IssueTracker/IssueTracker/View/LabelCollectionViewCell.xib
@@ -20,14 +20,14 @@
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="기능에 대한 레이블입니다." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wci-xK-FYZ">
                         <rect key="frame" x="20" y="82" width="284" height="93"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="19"/>
-                        <nil key="textColor"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <color key="textColor" systemColor="systemGray2Color"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="feature" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xQn-xw-em0">
                         <rect key="frame" x="20" y="56" width="54" height="21"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="21" id="QD8-CG-cGI"/>
+                            <constraint firstAttribute="height" priority="991" constant="21" id="QD8-CG-cGI"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
@@ -65,6 +65,9 @@
     </objects>
     <resources>
         <image name="chevron.right" catalog="system" width="96" height="128"/>
+        <systemColor name="systemGray2Color">
+            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemGrayColor">
             <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>


### PR DESCRIPTION
## 구현 항목
- 레이블 수정 및 추가 화면 레이아웃 구성 완료
- 필터 화면 레이아웃 구성(CollectionView Compositional Layout 구현)
- 이슈 화면에서 선택 모드 전환 방식 자체를 수정
View의 inset을 수정해서 변경하지 않고, 내장된 메서드를 사용해서 edit mode로 전환. collectionView를 edit mode로 전환할 경우, 자동으로 select button 생성.. registration 수정 불필요. 
registration을 수정해서 collectionView를 재설정하던 부분에서 메모리 릭이 발생했지만, 방식 자체를 수정함으로써 해결
- edit mode 일때, swipe가 되던 현상 없음.
- toolbar 추가 방식 변경
탭바 위에 추가하는 방식 -> 탭바를 숨기고 툴바 보여주기
이럴 경우, 툴바에서 constraint error가 나왔는데, 툴바 아이템을 edit모드로 들어갈 때, 추가해주는 방식으로 변경

## 실행화면
![Nov-04-2020 23-33-36](https://user-images.githubusercontent.com/31726630/98126060-82cb0d00-1ef8-11eb-928e-7657fac35a53.gif)
