### PR TITLE
[iOS-#81] add milestone edit VC

### DIFF
--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		14CC4F5606CBC1D30E2290A2 /* Pods_IssueTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B11756D279E0DA64222E52E5 /* Pods_IssueTracker.framework */; };
 		4C2787BB25500F6100E31035 /* SectionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2787BA25500F6100E31035 /* SectionItem.swift */; };
 		4C2787BF25500FD800E31035 /* ListCollectionViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2787BE25500FD800E31035 /* ListCollectionViewProtocol.swift */; };
+		4C3B3F092552ABC800231F67 /* BottomBorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3B3F082552ABC800231F67 /* BottomBorderView.swift */; };
+		4C44042C2551B07E0075AD9B /* Milestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C44042B2551B07E0075AD9B /* Milestone.swift */; };
+		4C4404342551BCBE0075AD9B /* MilestoneViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4404322551BCBE0075AD9B /* MilestoneViewCell.swift */; };
+		4C4404352551BCBE0075AD9B /* MilestoneViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4C4404332551BCBE0075AD9B /* MilestoneViewCell.xib */; };
 		4C7C11B8254E87CC008FA858 /* IssueDetailCommentViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7C11B6254E87CC008FA858 /* IssueDetailCommentViewCell.swift */; };
 		4C7C11B9254E87CC008FA858 /* IssueDetailCommentViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4C7C11B7254E87CC008FA858 /* IssueDetailCommentViewCell.xib */; };
 		4C7C11C3254EC6B9008FA858 /* IssueDetailHeaderReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7C11C1254EC6B8008FA858 /* IssueDetailHeaderReusableView.swift */; };
@@ -17,10 +21,9 @@
 		4CB6F8FD254D639300901E9D /* IssueDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB6F8FC254D639300901E9D /* IssueDetailViewController.swift */; };
 		4CD20476255141CD0001B987 /* IssueDetailBottomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD20475255141CD0001B987 /* IssueDetailBottomViewController.swift */; };
 		4CD2047925514E4C0001B987 /* CornerRoundedFloatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2047825514E4C0001B987 /* CornerRoundedFloatingView.swift */; };
-		4C44042C2551B07E0075AD9B /* Milestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C44042B2551B07E0075AD9B /* Milestone.swift */; };
-		4C4404342551BCBE0075AD9B /* MilestoneViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4404322551BCBE0075AD9B /* MilestoneViewCell.swift */; };
-		4C4404352551BCBE0075AD9B /* MilestoneViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4C4404332551BCBE0075AD9B /* MilestoneViewCell.xib */; };
 		4CD204882551A5230001B987 /* MilestoneViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD204872551A5230001B987 /* MilestoneViewController.swift */; };
+		4CDC3CAB2552F6E500FC672B /* NSLayoutConstraint+description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDC3CAA2552F6E500FC672B /* NSLayoutConstraint+description.swift */; };
+		4CDFDEA7255291F30084A19E /* MilestoneEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDFDEA6255291F30084A19E /* MilestoneEditViewController.swift */; };
 		C1048958255112230091668C /* IssueAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1048957255112230091668C /* IssueAddViewController.swift */; };
 		C104895B2551280C0091668C /* FilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C104895A2551280C0091668C /* FilterViewController.swift */; };
 		C104895E25515CA50091668C /* LabelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C104895D25515CA50091668C /* LabelViewController.swift */; };
@@ -45,6 +48,10 @@
 		0AC642BD38CA333388D53582 /* Pods-IssueTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.debug.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.debug.xcconfig"; sourceTree = "<group>"; };
 		4C2787BA25500F6100E31035 /* SectionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionItem.swift; sourceTree = "<group>"; };
 		4C2787BE25500FD800E31035 /* ListCollectionViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCollectionViewProtocol.swift; sourceTree = "<group>"; };
+		4C3B3F082552ABC800231F67 /* BottomBorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomBorderView.swift; sourceTree = "<group>"; };
+		4C44042B2551B07E0075AD9B /* Milestone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milestone.swift; sourceTree = "<group>"; };
+		4C4404322551BCBE0075AD9B /* MilestoneViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneViewCell.swift; sourceTree = "<group>"; };
+		4C4404332551BCBE0075AD9B /* MilestoneViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MilestoneViewCell.xib; sourceTree = "<group>"; };
 		4C7C11B6254E87CC008FA858 /* IssueDetailCommentViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailCommentViewCell.swift; sourceTree = "<group>"; };
 		4C7C11B7254E87CC008FA858 /* IssueDetailCommentViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueDetailCommentViewCell.xib; sourceTree = "<group>"; };
 		4C7C11C1254EC6B8008FA858 /* IssueDetailHeaderReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailHeaderReusableView.swift; sourceTree = "<group>"; };
@@ -52,10 +59,9 @@
 		4CB6F8FC254D639300901E9D /* IssueDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailViewController.swift; sourceTree = "<group>"; };
 		4CD20475255141CD0001B987 /* IssueDetailBottomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailBottomViewController.swift; sourceTree = "<group>"; };
 		4CD2047825514E4C0001B987 /* CornerRoundedFloatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRoundedFloatingView.swift; sourceTree = "<group>"; };
-		4C44042B2551B07E0075AD9B /* Milestone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milestone.swift; sourceTree = "<group>"; };
-		4C4404322551BCBE0075AD9B /* MilestoneViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneViewCell.swift; sourceTree = "<group>"; };
-		4C4404332551BCBE0075AD9B /* MilestoneViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MilestoneViewCell.xib; sourceTree = "<group>"; };
 		4CD204872551A5230001B987 /* MilestoneViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneViewController.swift; sourceTree = "<group>"; };
+		4CDC3CAA2552F6E500FC672B /* NSLayoutConstraint+description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+description.swift"; sourceTree = "<group>"; };
+		4CDFDEA6255291F30084A19E /* MilestoneEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneEditViewController.swift; sourceTree = "<group>"; };
 		B11756D279E0DA64222E52E5 /* Pods_IssueTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IssueTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1048957255112230091668C /* IssueAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAddViewController.swift; sourceTree = "<group>"; };
 		C104895A2551280C0091668C /* FilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewController.swift; sourceTree = "<group>"; };
@@ -100,6 +106,14 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		4CDC3CA92552F6C100FC672B /* extension */ = {
+			isa = PBXGroup;
+			children = (
+				4CDC3CAA2552F6E500FC672B /* NSLayoutConstraint+description.swift */,
+			);
+			path = extension;
+			sourceTree = "<group>";
+		};
 		530B9BB278546251FBEEAF99 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -134,6 +148,7 @@
 				4CD2047825514E4C0001B987 /* CornerRoundedFloatingView.swift */,
 				4C4404322551BCBE0075AD9B /* MilestoneViewCell.swift */,
 				4C4404332551BCBE0075AD9B /* MilestoneViewCell.xib */,
+				4C3B3F082552ABC800231F67 /* BottomBorderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -141,15 +156,16 @@
 		C117D8A72547C9380081DCD7 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				C104895D25515CA50091668C /* LabelViewController.swift */,
-				C10489722551986B0091668C /* LabelDetailAndAddViewController.swift */,
 				C104895A2551280C0091668C /* FilterViewController.swift */,
 				C1048957255112230091668C /* IssueAddViewController.swift */,
-				C117D89D2547C7CF0081DCD7 /* IssueViewController.swift */,
-				C196564B2546B9B6007DD55A /* ViewController.swift */,
-				4CB6F8FC254D639300901E9D /* IssueDetailViewController.swift */,
 				4CD20475255141CD0001B987 /* IssueDetailBottomViewController.swift */,
+				4CB6F8FC254D639300901E9D /* IssueDetailViewController.swift */,
+				C117D89D2547C7CF0081DCD7 /* IssueViewController.swift */,
+				C10489722551986B0091668C /* LabelDetailAndAddViewController.swift */,
+				C104895D25515CA50091668C /* LabelViewController.swift */,
+				4CDFDEA6255291F30084A19E /* MilestoneEditViewController.swift */,
 				4CD204872551A5230001B987 /* MilestoneViewController.swift */,
+				C196564B2546B9B6007DD55A /* ViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -175,6 +191,7 @@
 		C19656462546B9B6007DD55A /* IssueTracker */ = {
 			isa = PBXGroup;
 			children = (
+				4CDC3CA92552F6C100FC672B /* extension */,
 				C136F60B25495F93007A09F8 /* .swiftlint.yml */,
 				4C2787BD25500F8800E31035 /* Protocol */,
 				C117D8A72547C9380081DCD7 /* Controller */,
@@ -320,11 +337,13 @@
 			files = (
 				C117D89E2547C7CF0081DCD7 /* IssueViewController.swift in Sources */,
 				4C2787BF25500FD800E31035 /* ListCollectionViewProtocol.swift in Sources */,
+				4CDC3CAB2552F6E500FC672B /* NSLayoutConstraint+description.swift in Sources */,
 				C12542602547F44C00DE2BB8 /* IssueCollectionViewCell.swift in Sources */,
 				4C4404342551BCBE0075AD9B /* MilestoneViewCell.swift in Sources */,
 				C196564C2546B9B6007DD55A /* ViewController.swift in Sources */,
 				C19656602546CC4F007DD55A /* HTTPAgent.swift in Sources */,
 				C104895E25515CA50091668C /* LabelViewController.swift in Sources */,
+				4C3B3F092552ABC800231F67 /* BottomBorderView.swift in Sources */,
 				4C44042C2551B07E0075AD9B /* Milestone.swift in Sources */,
 				C19656482546B9B6007DD55A /* AppDelegate.swift in Sources */,
 				4CB6F8FD254D639300901E9D /* IssueDetailViewController.swift in Sources */,
@@ -334,6 +353,7 @@
 				C196564A2546B9B6007DD55A /* SceneDelegate.swift in Sources */,
 				4CD20476255141CD0001B987 /* IssueDetailBottomViewController.swift in Sources */,
 				4CD204882551A5230001B987 /* MilestoneViewController.swift in Sources */,
+				4CDFDEA7255291F30084A19E /* MilestoneEditViewController.swift in Sources */,
 				C104895B2551280C0091668C /* FilterViewController.swift in Sources */,
 				C10489732551986B0091668C /* LabelDetailAndAddViewController.swift in Sources */,
 				C196564A2546B9B6007DD55A /* SceneDelegate.swift in Sources */,

--- a/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -124,12 +124,8 @@
                     </navigationItem>
                     <connections>
                         <segue destination="Zva-Qn-br1" kind="presentation" identifier="newIssueSegue" id="Pck-2y-p0S"/>
-
-                        <segue destination="uYF-Zc-Jxh" kind="show" identifier="presentIssueEdit" id="Nuc-32-9lj"/>
                         <segue destination="oiX-ag-8Nt" kind="show" identifier="issueDetailSegue" id="zdS-aN-lOz"/>
-
                         <segue destination="cU1-Sd-kyi" kind="presentation" identifier="filterSegue" id="Pdg-FI-22b"/>
-
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="c3e-rB-1a3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -233,7 +229,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="V9n-id-ZiQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3788" y="-1248"/>
+            <point key="canvasLocation" x="3788" y="-1273"/>
         </scene>
         <!--Issue Add View Controller-->
         <scene sceneID="9hi-mu-K1D">
@@ -359,14 +355,14 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7pt-Yx-Yk1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3789" y="-574"/>
+            <point key="canvasLocation" x="4537" y="-1273"/>
         </scene>
         <!--Issue Detail View Controller-->
         <scene sceneID="gss-RP-GlC">
             <objects>
                 <viewController hidesBottomBarWhenPushed="YES" id="oiX-ag-8Nt" customClass="IssueDetailViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Hr8-1g-leQ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="oyJ-gc-mJa"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -387,18 +383,18 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Lh5-Dg-XeN" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3576.8000000000002" y="875.61576354679812"/>
+            <point key="canvasLocation" x="3788" y="-574"/>
         </scene>
         <!--Issue Detail Bottom View Controller-->
         <scene sceneID="Eu2-0p-PZB">
             <objects>
                 <viewController storyboardIdentifier="issueDetailBottomVC" id="Fly-Wc-ZSU" customClass="IssueDetailBottomViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="dWf-My-YGf" customClass="CornerRoundedFloatingView" customModule="IssueTracker" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L14-b5-iZc">
-                                <rect key="frame" x="167.66666666666666" y="10" width="40" height="6"/>
+                                <rect key="frame" x="175" y="10" width="40" height="6"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="6" id="BCF-2C-BJi"/>
@@ -411,7 +407,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sJZ-Go-YBs" customClass="CornerRoundedFloatingView" customModule="IssueTracker" customModuleProvider="target">
-                                <rect key="frame" x="255" y="26" width="100" height="50"/>
+                                <rect key="frame" x="270" y="26" width="100" height="50"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yi8-js-74W">
                                         <rect key="frame" x="49.666666666666686" y="0.0" width="1" height="50"/>
@@ -453,10 +449,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ewl-yj-YiC" customClass="CornerRoundedFloatingView" customModule="IssueTracker" customModuleProvider="target">
-                                <rect key="frame" x="20" y="26" width="215" height="50"/>
+                                <rect key="frame" x="20" y="26" width="230" height="50"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9IH-Gh-YFE">
-                                        <rect key="frame" x="0.0" y="0.0" width="215" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="230" height="50"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                         <state key="normal" title="Comment"/>
                                         <connections>
@@ -501,7 +497,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="goC-le-QKn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4349.6000000000004" y="875.61576354679812"/>
+            <point key="canvasLocation" x="4538" y="-582"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="JrQ-xi-R2Y">
@@ -575,7 +571,7 @@
                     <navigationItem key="navigationItem" title="마일스톤" id="bmu-iz-AAX">
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="hB1-GV-pb5">
                             <connections>
-                                <segue destination="1m3-1x-TNp" kind="presentation" id="3Ys-Lq-t3L"/>
+                                <segue destination="1m3-1x-TNp" kind="presentation" identifier="milestoneEditSegue" modalPresentationStyle="overFullScreen" modalTransitionStyle="crossDissolve" id="3Ys-Lq-t3L"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -584,20 +580,257 @@
             </objects>
             <point key="canvasLocation" x="3014" y="802"/>
         </scene>
-        <!--View Controller-->
+        <!--Milestone Edit View Controller-->
         <scene sceneID="T9J-c0-adv">
             <objects>
-                <viewController id="1m3-1x-TNp" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="milestoneEditViewController" id="1m3-1x-TNp" customClass="MilestoneEditViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="mWh-H4-BBK">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nGw-p7-3Ki" customClass="CornerRoundedFloatingView" customModule="IssueTracker" customModuleProvider="target">
+                                <rect key="frame" x="20" y="247" width="350" height="350"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="by8-am-hLx">
+                                        <rect key="frame" x="20" y="10" width="18" height="30"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" image="xmark" catalog="system"/>
+                                        <connections>
+                                            <action selector="closeButtonAction:" destination="1m3-1x-TNp" eventType="touchUpInside" id="E2q-UR-zyI"/>
+                                        </connections>
+                                    </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0sv-3j-b0z">
+                                        <rect key="frame" x="0.0" y="50" width="350" height="1"/>
+                                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="V1K-CF-FGD"/>
+                                        </constraints>
+                                    </view>
+                                    <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oWq-qe-ofQ">
+                                        <rect key="frame" x="20" y="51" width="310" height="241"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vl5-oe-JLZ">
+                                                <rect key="frame" x="0.0" y="0.0" width="310" height="180"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pHG-ZY-Lpv" customClass="BottomBorderView" customModule="IssueTracker" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="310" height="60"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KLR-zB-ihl">
+                                                                <rect key="frame" x="20" y="29" width="29.666666666666671" height="21"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gCk-Ow-JsM">
+                                                                <rect key="frame" x="69.666666666666671" y="31.333333333333314" width="220.33333333333331" height="18.666666666666671"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                        <constraints>
+                                                            <constraint firstItem="gCk-Ow-JsM" firstAttribute="leading" secondItem="KLR-zB-ihl" secondAttribute="trailing" constant="20" id="7UR-fe-hls"/>
+                                                            <constraint firstAttribute="bottom" secondItem="KLR-zB-ihl" secondAttribute="bottom" constant="10" id="IOw-RZ-FSV"/>
+                                                            <constraint firstAttribute="height" constant="60" id="TDC-Pi-3tJ"/>
+                                                            <constraint firstAttribute="trailing" secondItem="gCk-Ow-JsM" secondAttribute="trailing" constant="20" id="VTp-zU-zL7"/>
+                                                            <constraint firstItem="KLR-zB-ihl" firstAttribute="leading" secondItem="pHG-ZY-Lpv" secondAttribute="leading" constant="20" id="cz8-O2-DRY"/>
+                                                            <constraint firstItem="gCk-Ow-JsM" firstAttribute="bottom" secondItem="KLR-zB-ihl" secondAttribute="bottom" id="p35-GG-xbZ"/>
+                                                        </constraints>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cvt-Ln-EmV" customClass="BottomBorderView" customModule="IssueTracker" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="60" width="310" height="60"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="완료 날짜" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HgB-HH-KNS">
+                                                                <rect key="frame" x="20" y="9.3333333333333144" width="29.666666666666671" height="40.666666666666664"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="yyyy-mm-dd(선택)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QSF-Cd-kK0">
+                                                                <rect key="frame" x="69.666666666666671" y="20.333333333333314" width="220.33333333333331" height="18.666666666666671"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="bottom" secondItem="HgB-HH-KNS" secondAttribute="bottom" constant="10" id="7Dg-cT-gBs"/>
+                                                            <constraint firstItem="QSF-Cd-kK0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HgB-HH-KNS" secondAttribute="trailing" id="XnF-tY-aSx"/>
+                                                            <constraint firstItem="QSF-Cd-kK0" firstAttribute="centerY" secondItem="HgB-HH-KNS" secondAttribute="centerY" id="sad-xg-NcV"/>
+                                                        </constraints>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ffl-Uw-38x" customClass="BottomBorderView" customModule="IssueTracker" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="120" width="310" height="60"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Ai-nM-Qq8">
+                                                                <rect key="frame" x="20" y="29" width="29.666666666666671" height="21"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="v3k-TA-smI">
+                                                                <rect key="frame" x="69.666666666666671" y="31.333333333333314" width="220.33333333333331" height="18.666666666666671"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                        <constraints>
+                                                            <constraint firstItem="v3k-TA-smI" firstAttribute="bottom" secondItem="0Ai-nM-Qq8" secondAttribute="bottom" id="3NS-Qv-5iC"/>
+                                                            <constraint firstItem="v3k-TA-smI" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="0Ai-nM-Qq8" secondAttribute="trailing" id="DYR-fC-Q9A"/>
+                                                            <constraint firstAttribute="bottom" secondItem="0Ai-nM-Qq8" secondAttribute="bottom" constant="10" id="XE6-5f-r6i"/>
+                                                        </constraints>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="QSF-Cd-kK0" firstAttribute="leading" secondItem="gCk-Ow-JsM" secondAttribute="leading" id="073-4C-v5U"/>
+                                                    <constraint firstAttribute="trailing" secondItem="pHG-ZY-Lpv" secondAttribute="trailing" id="7Ij-FA-JmT"/>
+                                                    <constraint firstItem="cvt-Ln-EmV" firstAttribute="top" secondItem="pHG-ZY-Lpv" secondAttribute="bottom" id="Bwy-xN-C3V"/>
+                                                    <constraint firstItem="0Ai-nM-Qq8" firstAttribute="leading" secondItem="HgB-HH-KNS" secondAttribute="leading" id="Epm-So-MIr"/>
+                                                    <constraint firstItem="cvt-Ln-EmV" firstAttribute="height" secondItem="pHG-ZY-Lpv" secondAttribute="height" id="GYO-7d-lPo"/>
+                                                    <constraint firstItem="cvt-Ln-EmV" firstAttribute="leading" secondItem="vl5-oe-JLZ" secondAttribute="leading" id="QJ3-xg-cwj"/>
+                                                    <constraint firstItem="HgB-HH-KNS" firstAttribute="leading" secondItem="KLR-zB-ihl" secondAttribute="leading" id="Xdl-S6-sGF"/>
+                                                    <constraint firstItem="pHG-ZY-Lpv" firstAttribute="top" secondItem="vl5-oe-JLZ" secondAttribute="top" id="ZpR-b6-tR4"/>
+                                                    <constraint firstItem="Ffl-Uw-38x" firstAttribute="top" secondItem="cvt-Ln-EmV" secondAttribute="bottom" id="aP7-4r-ViW"/>
+                                                    <constraint firstItem="v3k-TA-smI" firstAttribute="trailing" secondItem="gCk-Ow-JsM" secondAttribute="trailing" id="b9c-FB-nE3"/>
+                                                    <constraint firstAttribute="height" constant="180" id="e6I-80-QlP"/>
+                                                    <constraint firstAttribute="trailing" secondItem="Ffl-Uw-38x" secondAttribute="trailing" id="fPV-BE-9nV"/>
+                                                    <constraint firstItem="Ffl-Uw-38x" firstAttribute="height" secondItem="pHG-ZY-Lpv" secondAttribute="height" id="ipC-3F-XZZ"/>
+                                                    <constraint firstItem="QSF-Cd-kK0" firstAttribute="trailing" secondItem="gCk-Ow-JsM" secondAttribute="trailing" id="mZh-LW-SIs"/>
+                                                    <constraint firstItem="v3k-TA-smI" firstAttribute="leading" secondItem="gCk-Ow-JsM" secondAttribute="leading" id="nn4-oa-aZo"/>
+                                                    <constraint firstAttribute="trailing" secondItem="cvt-Ln-EmV" secondAttribute="trailing" id="noW-GF-R9K"/>
+                                                    <constraint firstItem="Ffl-Uw-38x" firstAttribute="leading" secondItem="vl5-oe-JLZ" secondAttribute="leading" id="sFZ-jP-CiE"/>
+                                                    <constraint firstItem="pHG-ZY-Lpv" firstAttribute="leading" secondItem="vl5-oe-JLZ" secondAttribute="leading" id="yRn-fb-hvN"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="vl5-oe-JLZ" firstAttribute="top" secondItem="oWq-qe-ofQ" secondAttribute="top" id="7SU-jJ-hI9"/>
+                                            <constraint firstAttribute="trailing" secondItem="vl5-oe-JLZ" secondAttribute="trailing" id="DNo-zE-eIi"/>
+                                            <constraint firstItem="vl5-oe-JLZ" firstAttribute="leading" secondItem="oWq-qe-ofQ" secondAttribute="leading" id="STL-cR-mNW"/>
+                                            <constraint firstItem="vl5-oe-JLZ" firstAttribute="width" secondItem="oWq-qe-ofQ" secondAttribute="width" id="Sf6-wi-AhX"/>
+                                            <constraint firstAttribute="bottom" secondItem="vl5-oe-JLZ" secondAttribute="bottom" id="iY8-UE-oEV"/>
+                                        </constraints>
+                                        <viewLayoutGuide key="contentLayoutGuide" id="pNL-Tg-6gI"/>
+                                        <viewLayoutGuide key="frameLayoutGuide" id="uSZ-xt-yis"/>
+                                    </scrollView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lw3-tT-nOT">
+                                        <rect key="frame" x="20" y="310" width="39" height="30"/>
+                                        <state key="normal" title="초기화">
+                                            <color key="titleColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="resetButtonAction:" destination="1m3-1x-TNp" eventType="touchUpInside" id="o20-Lf-FKQ"/>
+                                        </connections>
+                                    </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NuW-hu-64G" customClass="CornerRoundedFloatingView" customModule="IssueTracker" customModuleProvider="target">
+                                        <rect key="frame" x="250" y="300" width="80" height="40"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RXC-FB-Kux">
+                                                <rect key="frame" x="0.0" y="0.0" width="80" height="40"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                                <state key="normal" title="저장">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="saveButtonAction:" destination="1m3-1x-TNp" eventType="touchUpInside" id="tpG-B1-bRx"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="RXC-FB-Kux" secondAttribute="bottom" id="IGB-W4-m5I"/>
+                                            <constraint firstAttribute="height" priority="999" constant="40" id="cXr-Tk-GQ0"/>
+                                            <constraint firstAttribute="width" secondItem="NuW-hu-64G" secondAttribute="height" multiplier="2:1" id="hbF-fg-nfS"/>
+                                            <constraint firstAttribute="trailing" secondItem="RXC-FB-Kux" secondAttribute="trailing" id="hlw-nH-5n9"/>
+                                            <constraint firstItem="RXC-FB-Kux" firstAttribute="top" secondItem="NuW-hu-64G" secondAttribute="top" id="lQb-Tv-fOn"/>
+                                            <constraint firstItem="RXC-FB-Kux" firstAttribute="leading" secondItem="NuW-hu-64G" secondAttribute="leading" id="osk-cz-rgT"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="NuW-hu-64G" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="lw3-tT-nOT" secondAttribute="trailing" id="AcY-9z-jrY"/>
+                                    <constraint firstAttribute="trailing" secondItem="0sv-3j-b0z" secondAttribute="trailing" id="BgR-aF-VRd"/>
+                                    <constraint firstItem="by8-am-hLx" firstAttribute="leading" secondItem="nGw-p7-3Ki" secondAttribute="leading" constant="20" id="DcQ-Yr-xzu"/>
+                                    <constraint firstItem="oWq-qe-ofQ" firstAttribute="top" secondItem="0sv-3j-b0z" secondAttribute="bottom" id="JMa-2a-sq2"/>
+                                    <constraint firstAttribute="width" priority="999" constant="1000" id="LEj-Vv-Zdj"/>
+                                    <constraint firstItem="NuW-hu-64G" firstAttribute="top" secondItem="oWq-qe-ofQ" secondAttribute="bottom" constant="8" id="Nhe-YF-Dll"/>
+                                    <constraint firstAttribute="bottom" secondItem="lw3-tT-nOT" secondAttribute="bottom" constant="10" id="Noe-Ln-Uc5"/>
+                                    <constraint firstItem="oWq-qe-ofQ" firstAttribute="leading" secondItem="nGw-p7-3Ki" secondAttribute="leading" constant="20" id="OS1-6g-Uu1"/>
+                                    <constraint firstItem="0sv-3j-b0z" firstAttribute="top" secondItem="nGw-p7-3Ki" secondAttribute="top" constant="50" id="OuH-k7-6Cl"/>
+                                    <constraint firstAttribute="width" secondItem="nGw-p7-3Ki" secondAttribute="height" multiplier="1:1" priority="999" id="Qci-Ij-QGb"/>
+                                    <constraint firstItem="0sv-3j-b0z" firstAttribute="top" secondItem="by8-am-hLx" secondAttribute="bottom" constant="10" id="VdI-Iq-txx"/>
+                                    <constraint firstItem="NuW-hu-64G" firstAttribute="trailing" secondItem="oWq-qe-ofQ" secondAttribute="trailing" id="Ys1-bv-PIa"/>
+                                    <constraint firstItem="lw3-tT-nOT" firstAttribute="leading" secondItem="by8-am-hLx" secondAttribute="leading" id="ZWo-Fa-isb"/>
+                                    <constraint firstAttribute="trailing" secondItem="oWq-qe-ofQ" secondAttribute="trailing" constant="20" id="aRg-s3-LCt"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="elJ-jG-IN9"/>
+                                    <constraint firstItem="by8-am-hLx" firstAttribute="top" secondItem="nGw-p7-3Ki" secondAttribute="top" constant="10" id="gMN-kt-gGE"/>
+                                    <constraint firstItem="0sv-3j-b0z" firstAttribute="leading" secondItem="nGw-p7-3Ki" secondAttribute="leading" id="nKG-Pe-Q6w"/>
+                                    <constraint firstItem="NuW-hu-64G" firstAttribute="bottom" secondItem="lw3-tT-nOT" secondAttribute="bottom" id="wWj-2y-KNc"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="shadowColor">
+                                        <color key="value" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="shadowRadius">
+                                        <real key="value" value="50"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="shadowOffsetY">
+                                        <real key="value" value="30"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="shadowOffsetX">
+                                        <real key="value" value="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="shadowOpacity">
+                                        <real key="value" value="0.29999999999999999"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRounding">
+                                        <real key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="jkZ-73-04w"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.2481806506849315" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstItem="nGw-p7-3Ki" firstAttribute="centerY" secondItem="mWh-H4-BBK" secondAttribute="centerY" id="OBm-hn-54s"/>
+                            <constraint firstItem="nGw-p7-3Ki" firstAttribute="top" relation="greaterThanOrEqual" secondItem="jkZ-73-04w" secondAttribute="top" constant="10" id="Y8R-Nd-o1C"/>
+                            <constraint firstItem="nGw-p7-3Ki" firstAttribute="centerX" secondItem="mWh-H4-BBK" secondAttribute="centerX" id="kvX-OC-qED"/>
+                            <constraint firstItem="nGw-p7-3Ki" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="jkZ-73-04w" secondAttribute="leading" constant="20" id="xDr-4F-BmA"/>
+                        </constraints>
                     </view>
+                    <navigationItem key="navigationItem" largeTitleDisplayMode="never" id="v7U-Rg-Dgy">
+                        <barButtonItem key="leftBarButtonItem" systemItem="stop" id="U70-78-pcd"/>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="descriptionTextField" destination="v3k-TA-smI" id="Jgv-4l-nE4"/>
+                        <outlet property="dueDateTextField" destination="QSF-Cd-kK0" id="sOs-2K-0Bd"/>
+                        <outlet property="popupView" destination="nGw-p7-3Ki" id="gub-hK-wkD"/>
+                        <outlet property="popupViewCenterYconstraint" destination="OBm-hn-54s" id="E9n-BB-GGk"/>
+                        <outlet property="titleTextField" destination="gCk-Ow-JsM" id="5ky-OF-Ba9"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7HF-kt-pfo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3788" y="802"/>
+            <point key="canvasLocation" x="3787.6923076923076" y="801.89573459715632"/>
         </scene>
         <!--마일스톤-->
         <scene sceneID="PPE-9e-Ykn">
@@ -620,16 +853,14 @@
         </scene>
     </scenes>
     <resources>
-
-        <image name="chevron.backward" catalog="system" width="96" height="128"/>
-        <image name="chevron.down" catalog="system" width="128" height="72"/>
-        <image name="chevron.up" catalog="system" width="128" height="72"/>
-
         <image name="1.circle.fill" catalog="system" width="128" height="121"/>
         <image name="2.circle.fill" catalog="system" width="128" height="121"/>
         <image name="3.circle.fill" catalog="system" width="128" height="121"/>
         <image name="baseline_queue_black_48pt" width="48" height="48"/>
-
+        <image name="chevron.backward" catalog="system" width="96" height="128"/>
+        <image name="chevron.down" catalog="system" width="128" height="72"/>
+        <image name="chevron.up" catalog="system" width="128" height="72"/>
+        <image name="xmark" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/ios/IssueTracker/IssueTracker/Controller/MilestoneEditViewController.swift
+++ b/ios/IssueTracker/IssueTracker/Controller/MilestoneEditViewController.swift
@@ -1,0 +1,84 @@
+//
+//  MilestoneEditViewController.swift
+//  IssueTracker
+//
+//  Created by 조기현 on 2020/11/04.
+//  Copyright © 2020 남기범. All rights reserved.
+//
+
+import UIKit
+
+class MilestoneEditViewController: UIViewController {
+
+	@IBOutlet weak var popupView: CornerRoundedFloatingView!
+	@IBOutlet weak var titleTextField: UITextField!
+	@IBOutlet weak var dueDateTextField: UITextField!
+	@IBOutlet weak var descriptionTextField: UITextField!
+	@IBOutlet weak var popupViewCenterYconstraint: NSLayoutConstraint!
+	
+	var milestone: Milestone?
+	var constraintInEditMode: NSLayoutConstraint?
+	
+	
+    override func viewDidLoad() {
+        super.viewDidLoad()
+		setupViews(milestone)
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(keyboardWillShow),
+			name: UIResponder.keyboardWillShowNotification,
+			object: nil
+		)
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(keyboardWillHide),
+			name: UIResponder.keyboardWillHideNotification,
+			object: nil
+		)
+    }
+	
+	func setupViews(_ milestone: Milestone?) {
+		titleTextField.text = milestone?.title
+		dueDateTextField.text = milestone?.dueDate?.description
+		descriptionTextField.text = milestone?.description
+	}
+	
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
+		titleTextField.becomeFirstResponder()
+	}
+	
+	override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+		view.endEditing(true)
+	}
+	
+	@objc func keyboardWillShow(_ notification: NSNotification) {
+		if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+			let keyboardRectangle = keyboardFrame.cgRectValue
+			let keyboardHeight = keyboardRectangle.height
+			
+			constraintInEditMode?.isActive = false
+			constraintInEditMode = view.safeAreaLayoutGuide.bottomAnchor.constraint(
+				equalTo: popupView.bottomAnchor,
+				constant: keyboardHeight + 20
+			)
+			popupViewCenterYconstraint.priority = .defaultLow
+			constraintInEditMode?.isActive = true
+		}
+	}
+	
+	@objc func keyboardWillHide(_ notification: NSNotification) {
+		constraintInEditMode?.isActive = false
+		popupViewCenterYconstraint.priority = .required
+	}
+    
+	@IBAction func closeButtonAction(_ sender: UIButton) {
+		dismiss(animated: true, completion: nil)
+	}
+	@IBAction func resetButtonAction(_ sender: UIButton) {
+		setupViews(milestone)
+	}
+	@IBAction func saveButtonAction(_ sender: UIButton) {
+		print("save")
+	}
+}

--- a/ios/IssueTracker/IssueTracker/Controller/MilestoneViewController.swift
+++ b/ios/IssueTracker/IssueTracker/Controller/MilestoneViewController.swift
@@ -32,11 +32,21 @@ class MilestoneViewController: UIViewController, ListCollectionViewProtocol {
 			Milestone(no: 2, title: "스프린트3", totalTasks: 0, closedTasks: 0, isClosed: false, isDeleted: false, dueDate: Date(), description: "다음 배포를 위한 스프린트")
 		]
 	}
+	
+	override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+		if let text = sender as? String,
+		   text == "edit",
+		   let editVC = segue.destination as? MilestoneEditViewController,
+		   let indexPath = collectionView.indexPathsForSelectedItems?.first {
+			editVC.milestone = list[indexPath.row]
+		}
+	}
 }
 
 extension MilestoneViewController {
 	func configureHierarchy() {
 		collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: createLayout())
+		collectionView.delegate = self
 		collectionView.backgroundColor = .clear
 		collectionView.register(UINib(nibName: "MilestoneViewCell", bundle: nil),
 								forCellWithReuseIdentifier: MilestoneViewCell.identifier)
@@ -82,5 +92,7 @@ extension MilestoneViewController {
 }
 
 extension MilestoneViewController: UICollectionViewDelegate {
-	
+	func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+		performSegue(withIdentifier: "milestoneEditSegue", sender: "edit")
+	}
 }

--- a/ios/IssueTracker/IssueTracker/View/BottomBorderView.swift
+++ b/ios/IssueTracker/IssueTracker/View/BottomBorderView.swift
@@ -1,0 +1,44 @@
+//
+//  BottomBorderView.swift
+//  IssueTracker
+//
+//  Created by 조기현 on 2020/11/04.
+//  Copyright © 2020 남기범. All rights reserved.
+//
+
+import UIKit
+
+@IBDesignable
+class BottomBorderView: UIView {
+
+	@IBInspectable
+	var borderColor: UIColor = .clear {
+		didSet {
+			border.backgroundColor = borderColor
+		}
+	}
+	
+	override func prepareForInterfaceBuilder() {
+		configure()
+	}
+
+	override func awakeFromNib() {
+		configure()
+	}
+    
+	let border = UIView()
+	func configure() {
+		addSubview(border)
+		border.translatesAutoresizingMaskIntoConstraints = false
+		NSLayoutConstraint.activate([
+			border.leadingAnchor.constraint(equalTo: leadingAnchor),
+			border.trailingAnchor.constraint(equalTo: trailingAnchor),
+			border.bottomAnchor.constraint(equalTo: bottomAnchor),
+			border.heightAnchor.constraint(equalToConstant: 0.5)
+		])
+		border.backgroundColor = borderColor
+		
+		
+	}
+
+}

--- a/ios/IssueTracker/IssueTracker/View/CornerRoundedFloatingView.swift
+++ b/ios/IssueTracker/IssueTracker/View/CornerRoundedFloatingView.swift
@@ -45,6 +45,12 @@ class CornerRoundedFloatingView: UIView {
 			layer.shadowRadius = shadowRadius
 		}
 	}
+	
+	@IBInspectable var bottomBorderColor: UIColor = .clear {
+		didSet {
+			bottomBorder.backgroundColor = bottomBorderColor.cgColor
+		}
+	}
     
 	override func prepareForInterfaceBuilder() {
 		configure()
@@ -54,7 +60,11 @@ class CornerRoundedFloatingView: UIView {
 		configure()
 	}
 	
+	let bottomBorder = CALayer()
+	
 	func configure() {
+		bottomBorder.backgroundColor = UIColor.clear.cgColor
+		layer.addSublayer(bottomBorder)
 		layer.cornerRadius = cornerRounding
 		layer.shadowColor = shadowColor.cgColor
 		layer.shadowOpacity = shadowOpacity

--- a/ios/IssueTracker/IssueTracker/extension/NSLayoutConstraint+description.swift
+++ b/ios/IssueTracker/IssueTracker/extension/NSLayoutConstraint+description.swift
@@ -1,0 +1,16 @@
+//
+//  NSLayoutConstraint+description.swift
+//  IssueTracker
+//
+//  Created by 조기현 on 2020/11/04.
+//  Copyright © 2020 남기범. All rights reserved.
+//
+
+import UIKit
+
+extension NSLayoutConstraint {
+	override public var description: String {
+		let id = identifier ?? ""
+		return "id: \(id), constant: \(constant)" //you may print whatever you want here
+	}
+}


### PR DESCRIPTION
## 구현 사항
- 마일스톤 추가/변경 화면 구현
- 오토레이아웃 적용 가로/세로 화면에 대응.
- 키보드가 올라오고 내려올 때, 제약을 변경해 주는데, 함수 실행 로직의 혼동으로 이전 제약을 지우지 않아 뷰가 찌그러지는 현상이 있었음.

![2020-11-05-10533](https://user-images.githubusercontent.com/21030956/98136099-e60e6c80-1f03-11eb-832c-f0b00976b1fa.gif)
![2020-11-05-10450](https://user-images.githubusercontent.com/21030956/98136101-e870c680-1f03-11eb-87a8-b144f0d18f0a.gif)
