### PR TITLE
[WEB-#90] 이슈 페이지 진행중, 공통 모달 구현 등

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -22,6 +22,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, '../frontend/dist')));
 app.use(session(config.session));
 app.use((req, res, next) => {
   res.locals.session = req.session;
@@ -37,8 +38,7 @@ app.all('*', (req, res) => {
     res.redirect(process.env.DEV_URL);
     return;
   }
-  // TODO : sendFile 경로 수정 -> frontend build 결과물의 index.html로 변경
-  res.sendFile(path.join(__dirname, 'public/index.html'));
+  res.sendFile(path.join(__dirname, '../frontend/dist/index.html'));
 });
 
 app.use((req, res, next) => {

--- a/backend/models/user.model.js
+++ b/backend/models/user.model.js
@@ -10,4 +10,8 @@ export const userModel = {
     const sql = 'INSERT INTO user (id, nickname, pw, auth) VALUES (?, ?, ?, ?);';
     return pool.execute(sql, [id, nickname, pw, auth ? auth : AUTH.DEFAULT]);
   },
+  getUsers() {
+    const sql = 'SELECT no, id, nickname, image FROM user;';
+    return pool.query(sql);
+  },
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start:dev": "cross-env MODE=dev nodemon --exec babel-node app.js",
     "start": "pm2 start app.js --interpreter node_modules/.bin/babel-node",
+    "local": "nodemon --exec babel-node app.js",
     "test": "jest"
   },
   "_moduleAliases": {

--- a/backend/routes/api/index.js
+++ b/backend/routes/api/index.js
@@ -5,6 +5,7 @@ import commentRouter from './comments';
 import issueRouter from './issues';
 import labelRouter from './labels';
 import milestoneRouter from './milestones';
+import userRouter from './users';
 
 const router = express.Router({ mergeParams: true });
 
@@ -13,5 +14,6 @@ router.use('/comments', authenticated, commentRouter);
 router.use('/issues', authenticated, issueRouter);
 router.use('/labels', authenticated, labelRouter);
 router.use('/milestones', authenticated, milestoneRouter);
+router.use('/users', userRouter);
 
 export default router;

--- a/backend/routes/api/users/index.js
+++ b/backend/routes/api/users/index.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as usersController from './users.controller';
+
+const router = express.Router({ mergeParams: true });
+
+router.get('/', usersController.getUsers);
+
+export default router;

--- a/backend/routes/api/users/users.controller.js
+++ b/backend/routes/api/users/users.controller.js
@@ -1,0 +1,13 @@
+import { userModel } from '@models';
+
+/**
+ * GET /api/users
+ */
+export const getUsers = async (req, res, next) => {
+  try {
+    const [users] = await userModel.getUsers();
+    res.json({ users });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/frontend/src/components/IssueList/IssueFilterTab/FilterBox/FilterBox.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/FilterBox/FilterBox.js
@@ -1,0 +1,66 @@
+import React, { useState, useRef } from 'react';
+import styled from 'styled-components';
+import downArrowIcon from '@imgs/down-arrow.svg';
+import { colors } from '@styles/variables';
+import { OptionSelectModal } from '@components';
+
+const FilterContainer = styled.div`
+  position: relative;
+  padding: 1rem 1.5rem;
+  margin-right: 0.2rem;
+`;
+
+const FilterButton = styled.div`
+  cursor: pointer;
+`;
+
+const FilterText = styled.span`
+  color: ${colors.black5};
+  &:hover {
+    color: ${colors.black1};
+  }
+`;
+
+const ArrowImg = styled.img`
+  width: 8px;
+  height: 8px;
+  margin-left: 5px;
+`;
+
+const Modal = styled.div`
+  position: absolute;
+  top: 3rem;
+  right: 1rem;
+  outline: 0;
+  z-index: 2;
+`;
+
+export default function FilterBox({ items, name, title }) {
+  const modal = useRef();
+
+  const [visiable, setVisiable] = useState(false);
+
+  const openModal = () => {
+    setVisiable(true);
+    modal.current.focus();
+  };
+
+  const closeAuthorModal = () => setVisiable(false);
+
+  return (
+    <FilterContainer>
+      <FilterButton onClick={openModal}>
+        <FilterText>{name}</FilterText>
+        <ArrowImg src={downArrowIcon} />
+      </FilterButton>
+      <Modal tabIndex={0} ref={modal} onBlur={closeAuthorModal}>
+        <OptionSelectModal
+          visiable={visiable}
+          setVisiable={setVisiable}
+          title={title}
+          items={items}
+        />
+      </Modal>
+    </FilterContainer>
+  );
+}

--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -5,14 +5,13 @@ const Container = styled.div`
   border: 1px solid gray;
 `;
 
-export default function IssueFilterTab({ setIssues, issues, setCheckAll, checkAll }) {
+export default function IssueFilterTab({ setIssues, issues, allChecked }) {
   const handleCheck = ({ target: { checked } }) => {
     setIssues(issues.map(issue => ({ ...issue, checked })));
-    setCheckAll(checked);
   };
   return (
     <Container>
-      <input type="checkbox" checked={checkAll} onChange={handleCheck} />
+      <input type="checkbox" onChange={handleCheck} checked={allChecked} />
       Filter Tab
     </Container>
   );

--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -1,4 +1,3 @@
-import { check } from 'prettier';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -6,14 +5,14 @@ const Container = styled.div`
   border: 1px solid gray;
 `;
 
-export default function IssueFilterTab({ setIssues, issues, setHeadCheck, headCheck }) {
+export default function IssueFilterTab({ setIssues, issues, setCheckAll, checkAll }) {
   const handleCheck = ({ target: { checked } }) => {
     setIssues(issues.map(issue => ({ ...issue, checked })));
-    setHeadCheck(checked);
+    setCheckAll(checked);
   };
   return (
     <Container>
-      <input type="checkbox" checked={headCheck} onChange={handleCheck} />
+      <input type="checkbox" checked={checkAll} onChange={handleCheck} />
       Filter Tab
     </Container>
   );

--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -1,59 +1,60 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { flex } from '@styles/utils';
-import downArrowIcon from '@imgs/down-arrow.svg';
-import { colors } from '@styles/variables';
+import { userService } from '@services';
+import FilterBox from './FilterBox/FilterBox';
 
 const Container = styled.div`
   border: 1px solid gray;
   ${flex('space-between', 'center')}
 `;
 
-const FilterBox = styled.div`
+const FilterList = styled.div`
   ${flex()}
 `;
 
-const Filter = styled.div`
-  padding: 1rem 1.5rem;
-  margin-right: 0.2rem;
-  cursor: pointer;
-  color: ${colors.black5};
-  &:hover {
-    color: ${colors.black1};
-  }
-`;
-
-const ArrowImg = styled.img`
-  width: 8px;
-  height: 8px;
-  margin-left: 5px;
-`;
+const filterState = {
+  users: [],
+  labels: [],
+  milestones: [],
+};
 
 export default function IssueFilterTab({ setIssues, issues, allChecked }) {
   const handleCheck = ({ target: { checked } }) => {
     setIssues(issues.map(issue => ({ ...issue, checked })));
   };
+
+  const [filterList, setFilterList] = useState(filterState);
+  const { users, labels, milestones } = filterList;
+
+  const fetchAllDatas = async () => {
+    try {
+      const [
+        {
+          data: { users },
+        },
+      ] = await Promise.all([userService.getUsers()]);
+      setFilterList({ ...filterList, users });
+    } catch ({ response: { status } }) {
+      if (status === 401) {
+        history.push('/login');
+      }
+    }
+  };
+
+  useEffect(() => {
+    fetchAllDatas();
+  }, []);
+
   return (
     <Container>
       <input type="checkbox" onChange={handleCheck} checked={allChecked} />
-      <FilterBox>
-        <Filter>
-          Author
-          <ArrowImg src={downArrowIcon} />
-        </Filter>
-        <Filter>
-          Label
-          <ArrowImg src={downArrowIcon} />
-        </Filter>
-        <Filter>
-          Milestones
-          <ArrowImg src={downArrowIcon} />
-        </Filter>
-        <Filter>
-          Assignee
-          <ArrowImg src={downArrowIcon} />
-        </Filter>
-      </FilterBox>
+      <FilterList>
+        <FilterBox name="Author" title="Filter by author" items={users} />
+        <FilterBox name="Label" title="Filter by label" items={labels} />
+        <FilterBox name="Milestones" title="Filter by milestone" items={milestones} />
+        <FilterBox name="Assignees" title={`Filter by who's assigned`} items={users} />
+      </FilterList>
     </Container>
   );
 }

--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -1,3 +1,4 @@
+import { check } from 'prettier';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -5,10 +6,14 @@ const Container = styled.div`
   border: 1px solid gray;
 `;
 
-export default function IssueFilterTab() {
+export default function IssueFilterTab({ setIssues, issues, setHeadCheck, headCheck }) {
+  const handleCheck = ({ target: { checked } }) => {
+    setIssues(issues.map(issue => ({ ...issue, checked })));
+    setHeadCheck(checked);
+  };
   return (
     <Container>
-      <input type="checkbox" />
+      <input type="checkbox" checked={headCheck} onChange={handleCheck} />
       Filter Tab
     </Container>
   );

--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -1,8 +1,32 @@
 import React from 'react';
 import styled from 'styled-components';
+import { flex } from '@styles/utils';
+import downArrowIcon from '@imgs/down-arrow.svg';
+import { colors } from '@styles/variables';
 
 const Container = styled.div`
   border: 1px solid gray;
+  ${flex('space-between', 'center')}
+`;
+
+const FilterBox = styled.div`
+  ${flex()}
+`;
+
+const Filter = styled.div`
+  padding: 1rem 1.5rem;
+  margin-right: 0.2rem;
+  cursor: pointer;
+  color: ${colors.black5};
+  &:hover {
+    color: ${colors.black1};
+  }
+`;
+
+const ArrowImg = styled.img`
+  width: 8px;
+  height: 8px;
+  margin-left: 5px;
 `;
 
 export default function IssueFilterTab({ setIssues, issues, allChecked }) {
@@ -12,7 +36,24 @@ export default function IssueFilterTab({ setIssues, issues, allChecked }) {
   return (
     <Container>
       <input type="checkbox" onChange={handleCheck} checked={allChecked} />
-      Filter Tab
+      <FilterBox>
+        <Filter>
+          Author
+          <ArrowImg src={downArrowIcon} />
+        </Filter>
+        <Filter>
+          Label
+          <ArrowImg src={downArrowIcon} />
+        </Filter>
+        <Filter>
+          Milestones
+          <ArrowImg src={downArrowIcon} />
+        </Filter>
+        <Filter>
+          Assignee
+          <ArrowImg src={downArrowIcon} />
+        </Filter>
+      </FilterBox>
     </Container>
   );
 }

--- a/frontend/src/components/IssueList/IssueItem/IssueItem.js
+++ b/frontend/src/components/IssueList/IssueItem/IssueItem.js
@@ -5,7 +5,7 @@ const Container = styled.div`
   border: 1px solid gray;
 `;
 
-export default function IssueItem({ checked, issues, title, setCheckAll, setIssues }) {
+export default function IssueItem({ checked, issues, title, setIssues }) {
   const handleCheck = ({ target }) => {
     setIssues(
       issues.map(issue => (issue.title === title ? { ...issue, checked: target.checked } : issue)),

--- a/frontend/src/components/IssueList/IssueItem/IssueItem.js
+++ b/frontend/src/components/IssueList/IssueItem/IssueItem.js
@@ -5,11 +5,19 @@ const Container = styled.div`
   border: 1px solid gray;
 `;
 
-export default function IssueItem() {
+export default function IssueItem({ checked, issues, title, setHeadCheck, setIssues }) {
+  const handleCheck = ({ target }) => {
+    setIssues(
+      issues.map(issue => (issue.title === title ? { ...issue, checked: target.checked } : issue)),
+    );
+    if (!target.checked) {
+      setHeadCheck(false);
+    }
+  };
   return (
     <Container>
-      <input type="checkbox" />
-      Issue Item
+      <input type="checkbox" checked={checked} onChange={handleCheck} />
+      {title}
     </Container>
   );
 }

--- a/frontend/src/components/IssueList/IssueItem/IssueItem.js
+++ b/frontend/src/components/IssueList/IssueItem/IssueItem.js
@@ -10,9 +10,6 @@ export default function IssueItem({ checked, issues, title, setCheckAll, setIssu
     setIssues(
       issues.map(issue => (issue.title === title ? { ...issue, checked: target.checked } : issue)),
     );
-    if (!target.checked) {
-      setCheckAll(false);
-    }
   };
   return (
     <Container>

--- a/frontend/src/components/IssueList/IssueItem/IssueItem.js
+++ b/frontend/src/components/IssueList/IssueItem/IssueItem.js
@@ -5,13 +5,13 @@ const Container = styled.div`
   border: 1px solid gray;
 `;
 
-export default function IssueItem({ checked, issues, title, setHeadCheck, setIssues }) {
+export default function IssueItem({ checked, issues, title, setCheckAll, setIssues }) {
   const handleCheck = ({ target }) => {
     setIssues(
       issues.map(issue => (issue.title === title ? { ...issue, checked: target.checked } : issue)),
     );
     if (!target.checked) {
-      setHeadCheck(false);
+      setCheckAll(false);
     }
   };
   return (

--- a/frontend/src/components/IssueList/IssueList.js
+++ b/frontend/src/components/IssueList/IssueList.js
@@ -6,8 +6,8 @@ import { useHistory } from 'react-router-dom';
 
 export default function IssueList() {
   const [issues, setIssues] = useState([]);
-  const [checkAll, setCheckAll] = useState(false);
   const history = useHistory();
+  const allChecked = issues.every(i => i.checked);
 
   const setFilterdIssues = async options => {
     try {
@@ -29,12 +29,7 @@ export default function IssueList() {
 
   return (
     <>
-      <IssueFilterTab
-        issues={issues}
-        setIssues={setIssues}
-        checkAll={checkAll}
-        setCheckAll={setCheckAll}
-      />
+      <IssueFilterTab issues={issues} setIssues={setIssues} allChecked={allChecked} />
       {issues.map(({ title, checked }, idx) => (
         <IssueItem
           key={idx}
@@ -42,7 +37,6 @@ export default function IssueList() {
           checked={checked}
           issues={issues}
           setIssues={setIssues}
-          setCheckAll={setCheckAll}
         />
       ))}
     </>

--- a/frontend/src/components/IssueList/IssueList.js
+++ b/frontend/src/components/IssueList/IssueList.js
@@ -1,17 +1,49 @@
-import React, { useState } from 'react';
-import IssueSearchBox from './IssueSearchBar/IssueSearchBar';
+import React, { useEffect, useState } from 'react';
+import { issueService } from '@services';
 import IssueFilterTab from './IssueFilterTab/IssueFilterTab';
 import IssueItem from './IssueItem/IssueItem';
+import { useHistory } from 'react-router-dom';
 
 export default function IssueList() {
-  const [checkAll, setCheckAll] = useState(false);
-  const tempIssues = ['a', 'b', 'c'];
+  const [issues, setIssues] = useState([]);
+  const [headCheck, setHeadCheck] = useState(false);
+  const history = useHistory();
+
+  const setFilterdIssues = async options => {
+    try {
+      const {
+        data: { issues },
+        status,
+      } = await issueService.getIssues(options);
+      if (status === 200) {
+        setIssues(issues.map(issue => ({ ...issue, checked: false })));
+      }
+    } catch (err) {
+      history.push('/login');
+    }
+  };
+
+  useEffect(() => {
+    setFilterdIssues();
+  }, []);
+
   return (
     <>
-      <IssueSearchBox />
-      <IssueFilterTab />
-      {tempIssues.map((item, idx) => (
-        <IssueItem key={idx} />
+      <IssueFilterTab
+        issues={issues}
+        setIssues={setIssues}
+        headCheck={headCheck}
+        setHeadCheck={setHeadCheck}
+      />
+      {issues.map(({ title, checked }, idx) => (
+        <IssueItem
+          key={idx}
+          title={title}
+          checked={checked}
+          issues={issues}
+          setIssues={setIssues}
+          setHeadCheck={setHeadCheck}
+        />
       ))}
     </>
   );

--- a/frontend/src/components/IssueList/IssueList.js
+++ b/frontend/src/components/IssueList/IssueList.js
@@ -18,8 +18,10 @@ export default function IssueList() {
       if (status === 200) {
         setIssues(issues.map(issue => ({ ...issue, checked: false })));
       }
-    } catch (err) {
-      history.push('/login');
+    } catch ({ response: { status } }) {
+      if (status === 401) {
+        history.push('/login');
+      }
     }
   };
 

--- a/frontend/src/components/IssueList/IssueList.js
+++ b/frontend/src/components/IssueList/IssueList.js
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router-dom';
 
 export default function IssueList() {
   const [issues, setIssues] = useState([]);
-  const [headCheck, setHeadCheck] = useState(false);
+  const [checkAll, setCheckAll] = useState(false);
   const history = useHistory();
 
   const setFilterdIssues = async options => {
@@ -32,8 +32,8 @@ export default function IssueList() {
       <IssueFilterTab
         issues={issues}
         setIssues={setIssues}
-        headCheck={headCheck}
-        setHeadCheck={setHeadCheck}
+        checkAll={checkAll}
+        setCheckAll={setCheckAll}
       />
       {issues.map(({ title, checked }, idx) => (
         <IssueItem
@@ -42,7 +42,7 @@ export default function IssueList() {
           checked={checked}
           issues={issues}
           setIssues={setIssues}
-          setHeadCheck={setHeadCheck}
+          setCheckAll={setCheckAll}
         />
       ))}
     </>

--- a/frontend/src/components/IssueSearchBox/IssueSearchBox.js
+++ b/frontend/src/components/IssueSearchBox/IssueSearchBox.js
@@ -85,7 +85,7 @@ const ClearButton = styled.button`
   cursor: pointer;
 `;
 
-export default function IssueSearchBar() {
+export default function IssueSearchBox() {
   return (
     <SearchContainer>
       <SearchBox>

--- a/frontend/src/components/LoginBox/LocalBox/LocalBox.js
+++ b/frontend/src/components/LoginBox/LocalBox/LocalBox.js
@@ -67,13 +67,13 @@ export default function LocalBox() {
     e.preventDefault();
     try {
       const { status } = await userService.login({ id, pw });
-      console.log('here', status);
       if (status === 200) {
         history.push('/');
       }
-    } catch (err) {
-      console.error(err);
-      setErrMsg('아이디와 비밀번호를 확인해주세요');
+    } catch ({ response: { status } }) {
+      if (status === 401) {
+        setErrMsg('아이디와 비밀번호를 확인해주세요');
+      }
     }
   };
 
@@ -95,7 +95,7 @@ export default function LocalBox() {
           onChange={handleInputChange}
           value={pw}
           required
-          autoComplete={true}
+          autoComplete="true"
         />
         <ErrMsgSpan>{errMsg}</ErrMsgSpan>
       </InputBox>

--- a/frontend/src/components/LoginBox/LocalBox/LocalBox.js
+++ b/frontend/src/components/LoginBox/LocalBox/LocalBox.js
@@ -67,11 +67,12 @@ export default function LocalBox() {
     e.preventDefault();
     try {
       const { status } = await userService.login({ id, pw });
+      console.log('here', status);
       if (status === 200) {
         history.push('/');
       }
     } catch (err) {
-      console.log(err);
+      console.error(err);
       setErrMsg('아이디와 비밀번호를 확인해주세요');
     }
   };
@@ -86,9 +87,16 @@ export default function LocalBox() {
     <LoginForm onSubmit={handleSubmit}>
       <InputBox>
         <Label htmlFor="id">아이디</Label>
-        <Input name="id" type="text" onChange={handleInputChange} value={id} />
+        <Input name="id" type="text" onChange={handleInputChange} value={id} required />
         <Label htmlFor="pw">비밀번호</Label>
-        <Input name="pw" type="password" onChange={handleInputChange} value={pw} />
+        <Input
+          name="pw"
+          type="password"
+          onChange={handleInputChange}
+          value={pw}
+          required
+          autoComplete={true}
+        />
         <ErrMsgSpan>{errMsg}</ErrMsgSpan>
       </InputBox>
       <ButtonBox>

--- a/frontend/src/components/LoginBox/LocalBox/LocalBox.js
+++ b/frontend/src/components/LoginBox/LocalBox/LocalBox.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { API } from '@api';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
+import { userService } from '@services';
 
 const LoginForm = styled.form`
   display: flex;
@@ -59,13 +59,14 @@ const ErrMsgSpan = styled.span`
 export default function LocalBox() {
   const [errMsg, setErrMsg] = useState('');
   const [form, setForm] = useState({ id: '', pw: '' });
+  const { id, pw } = form;
 
   const history = useHistory();
 
   const handleSubmit = async e => {
     e.preventDefault();
     try {
-      const { status } = await API.post('/api/auth/login', { id, pw });
+      const { status } = await userService.login({ id, pw });
       if (status === 200) {
         history.push('/');
       }
@@ -81,13 +82,6 @@ export default function LocalBox() {
     setErrMsg('');
   };
 
-  const handleSignup = e => {
-    e.preventDefault();
-    // TODO : 회원가입 처리 구현
-  };
-
-  const { id, pw } = form;
-
   return (
     <LoginForm onSubmit={handleSubmit}>
       <InputBox>
@@ -99,7 +93,9 @@ export default function LocalBox() {
       </InputBox>
       <ButtonBox>
         <LoginButton>로그인</LoginButton>
-        <SignupButton onClick={handleSignup}>회원 가입</SignupButton>
+        <Link to="/signup">
+          <SignupButton>회원 가입</SignupButton>
+        </Link>
       </ButtonBox>
     </LoginForm>
   );

--- a/frontend/src/components/OptionSelectModal/OptionSelectModal.js
+++ b/frontend/src/components/OptionSelectModal/OptionSelectModal.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import styled from 'styled-components';
+import { colors } from '@styles/variables';
+import closeDarkIcon from '@imgs/close-dark.svg';
+import { flex } from '@styles/utils';
+
+const Container = styled.div`
+  width: 18.5rem;
+  border: 1px solid ${colors.lightGray};
+  border-radius: 5px;
+  background-color: white;
+  color: ${colors.black4};
+`;
+
+const Header = styled.div`
+  font-size: 0.8rem;
+  font-weight: bold;
+  border-bottom: 1px solid ${colors.lightGray};
+  padding: 0.5rem 0 0.5rem 0.5rem;
+  ${flex('space-between', 'center')}
+`;
+
+const CloseImg = styled.img`
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-right: 0.4rem;
+  cursor: pointer;
+`;
+
+const ListBox = styled.div`
+  max-height: 20rem;
+  overflow-y: scroll;
+`;
+
+const ListItem = styled.div`
+  font-size: 0.8rem;
+  padding: 0.5rem 0 0.5rem 0.7rem;
+  border-bottom: 1px solid ${colors.lightGray};
+  cursor: pointer;
+`;
+
+export default function OptionSelectModal({ visiable, setVisiable, title, items }) {
+  const handleClose = () => {
+    setVisiable(false);
+  };
+
+  return (
+    <>
+      {visiable ? (
+        <Container>
+          <Header>
+            <span>{title}</span>
+            <CloseImg src={closeDarkIcon} onClick={handleClose} />
+          </Header>
+          {/* TODO 여기서 ListBox를 외부에서 주입받아야 함. Author, Label,.. 등등 각각의 값이 다름 */}
+          <ListBox>
+            {items.map(({ nickname }, idx) => (
+              <ListItem key={idx}>{nickname}</ListItem>
+            ))}
+          </ListBox>
+        </Container>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/components/SignUpBox/SignUpBox.js
+++ b/frontend/src/components/SignUpBox/SignUpBox.js
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { API } from '@api';
 import { flexColumn } from '@styles/utils';
 import { useHistory } from 'react-router-dom';
 import { AUTH } from '@constants/index';
+import { userService } from '@services';
 
 const SignUpContainer = styled.div`
   background-color: #ecf0f1;
@@ -64,15 +64,17 @@ export default function SignUpBox() {
 
   const handleSubmit = async e => {
     e.preventDefault();
-    const data = { id, nickname, pw, auth: AUTH.DEFAULT };
     try {
-      const { status } = await API.post('/api/auth/signup', data);
+      const { data, status } = await userService.signup({ id, nickname, pw, auth: AUTH.DEFAULT });
       if (status === 200) {
         history.push('/login');
+        return;
       }
       // TODO 200 이외의 코드 에러 처리
     } catch (err) {
       console.error(err);
+      // TODO : 아이디 닉네임 중복 처리 구현하고 아래 alert 삭제
+      alert('중복된 아이디 또는 닉네임입니다.');
     }
   };
 

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -2,8 +2,8 @@ export { default as Header } from './Header/Header';
 export { default as LoginBox } from './LoginBox/LoginBox';
 export { default as SignUpBox } from './SignUpBox/SignUpBox';
 export { default as IssueList } from './IssueList/IssueList';
+export { default as IssueSearchBox } from './IssueSearchBox/IssueSearchBox';
 export { default as LabelMilestoneControls } from './LabelMilestoneControls/LabelMilestoneControls';
 export { default as LabelBox } from './LabelBox/LabelBox';
 export { default as MilestoneEditBox } from './MilestoneEditBox/MilestoneEditBox';
 export { default as MilestoneNewHeader } from './MilestoneNewHeader/MilestoneNewHeader';
-

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -7,3 +7,4 @@ export { default as LabelMilestoneControls } from './LabelMilestoneControls/Labe
 export { default as LabelBox } from './LabelBox/LabelBox';
 export { default as MilestoneEditBox } from './MilestoneEditBox/MilestoneEditBox';
 export { default as MilestoneNewHeader } from './MilestoneNewHeader/MilestoneNewHeader';
+export { default as OptionSelectModal } from './OptionSelectModal/OptionSelectModal';

--- a/frontend/src/imgs/close-dark.svg
+++ b/frontend/src/imgs/close-dark.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="200px" height="200px" viewBox="0 0 200 200" enable-background="new 0 0 200 200" xml:space="preserve">
+<g>
+	
+		<rect x="38.284" y="91.534" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 99.9984 241.421)" fill="#333333" width="123.431" height="16.932"/>
+	
+		<rect x="91.536" y="38.284" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 99.9995 241.4202)" fill="#333333" width="16.928" height="123.43"/>
+</g>
+</svg>

--- a/frontend/src/pages/Issue.js
+++ b/frontend/src/pages/Issue.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Header, IssueList } from '@components';
+import { Header, IssueList, IssueSearchBox } from '@components';
 
 const IssueContainer = styled.div`
   width: calc(100% - 160px);
@@ -12,6 +12,7 @@ export default function Issue() {
     <>
       <Header />
       <IssueContainer>
+        <IssueSearchBox />
         <IssueList />
       </IssueContainer>
     </>

--- a/frontend/src/services/index.js
+++ b/frontend/src/services/index.js
@@ -1,0 +1,2 @@
+export { issueService } from './issue.service';
+export { userService } from './user.service';

--- a/frontend/src/services/issue.service.js
+++ b/frontend/src/services/issue.service.js
@@ -1,0 +1,7 @@
+import { API } from '@api';
+
+export const issueService = {
+  getIssues() {
+    return API.get('/api/issues');
+  },
+};

--- a/frontend/src/services/issue.service.js
+++ b/frontend/src/services/issue.service.js
@@ -1,7 +1,7 @@
 import { API } from '@api';
 
 export const issueService = {
-  getIssues() {
-    return API.get('/api/issues');
+  getIssues(options) {
+    return API.get('/api/issues', options);
   },
 };

--- a/frontend/src/services/user.service.js
+++ b/frontend/src/services/user.service.js
@@ -4,6 +4,9 @@ export const userService = {
   login({ id, pw }) {
     return API.post('/api/auth/login', { id, pw });
   },
+  logout() {
+    return API.post('/api/auth/logout');
+  },
   signup({ id, nickname, pw, auth }) {
     return API.post('/api/auth/signup', { id, nickname, pw, auth });
   },

--- a/frontend/src/services/user.service.js
+++ b/frontend/src/services/user.service.js
@@ -4,4 +4,7 @@ export const userService = {
   login({ id, pw }) {
     return API.post('/api/auth/login', { id, pw });
   },
+  signup({ id, nickname, pw, auth }) {
+    return API.post('/api/auth/signup', { id, nickname, pw, auth });
+  },
 };

--- a/frontend/src/services/user.service.js
+++ b/frontend/src/services/user.service.js
@@ -10,4 +10,7 @@ export const userService = {
   signup({ id, nickname, pw, auth }) {
     return API.post('/api/auth/signup', { id, nickname, pw, auth });
   },
+  getUsers() {
+    return API.get('/api/users');
+  },
 };

--- a/frontend/src/services/user.service.js
+++ b/frontend/src/services/user.service.js
@@ -1,0 +1,7 @@
+import { API } from '@api';
+
+export const userService = {
+  login({ id, pw }) {
+    return API.post('/api/auth/login', { id, pw });
+  },
+};


### PR DESCRIPTION
## 구현 요약 사진
![image](https://user-images.githubusercontent.com/61396464/98266517-c479b780-1fcd-11eb-975a-48be984a3be8.png)


## 구현 사항

### 1.  OptionSelectModal 구현
  - 필터 선택했을 때 뜨는 Modal창을 일부 구현했습니다. 공통으로 재활용하기는 좋은데, Author, Label, Milestones의 객체 값들이 각각 달라서 그 부분을 밖에서 주입받는 형태로 변경할 계획입니다.
  - Modal이 focusOut 되었을 때 자동으로 사라지도록 구현했습니다. 박스의 X 버튼을 눌러도 사라집니다.

### 2. 체크박스 전체선택/취소 구현
  - 필터 탭의 체크박스를 누르면 모두 선택/취소가 됩니다.
  - 하위 요소들의 체크박스가 하나라도 모자라면, 필터 탭의 체크박스는 해제됩니다.
  - 마찬가지로 하위 요소들의 체크박스가 모두 선택되면, 필터 탭의 체크박스도 선택으로 바뀝니다.

### 3. 이슈 목록 불러와서 렌더링
  - getIssues로 이슈들을 불러와서 렌더링 했습니다.

### 4. Author필터와 Assignee 필터에 목록 출력
  - getUsers로 유저 목록을 불러와서 필터 모달에 채워넣었습니다.
  - label과 milestone은 객체 형태가 달라서 OptionSelectModal을 수정 후 구현할 계획입니다.

### 5. Axios의 응답코드가 200 ~300이 아닐 때 catch로 빠지는 케이스 처리
  - axios에 응답코드가 200 이상 300이하가 아닐때는 catch 부분으로 빠집니다. 응답 코드를 확인 후 처리하는 방식으로 바꾸려면 아래와 같이 작성해주세요. (err.response.status 로 접근하면 status코드가 나옵니다.)
  ```js
    catch ({ response: { status } }) {
      if (status === 401) {
        history.push('/login');
       }
     }
  ```

### 6. 백엔드에 users 컨트롤러 및 모델 구현
  - 해당 컨트롤러가 구현이 안되어있어서 구현했습니다.

### 7. Axios API 요청하는 부분을 수정
  - 각 컴포넌트에서 API.get() 이런식으로 직접 요청하는 코드는 모두 service로 보냈습니다. 앞으로 API 요청을 service로 분리해주시면 좋을 것 같아요~

### 8. login 컴포넌트에서 input에 required 옵션 지정
  - 필수값인 경우 input의 속성으로 required를 넣어주세요. type에 따라서 값도 검증해줍니다! 
  - (ex. type="email"이면 email인지 체크해줌)

### 9. 로그인 이나 회원 가입 후 redirect
  - redirect가 필요한 부분에 구현했습니다.

### 10. 배포 테스트 완료
  - 로컬에서 프론트 빌드하고 백엔드와 연결했더니 잘 동작하네요. 이 PR 머지하면 배포해볼게요.

---

뭔가 많이 한거같은데 화면 변화는 크게 없어서 슬프네요 하하🤣

---