### PR TITLE
[WEB-#90] 이슈 페이지 추가 구현 

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -16,7 +16,7 @@ import passportConfig from './lib/passport';
 const app = express();
 const port = process.env.PORT || 3000;
 
-app.use(cors());
+app.use(cors({ origin: 'http://localhost:8080', credentials: true }));
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+git checkout web
+git fetch
+
+head=`git rev-parse HEAD`
+origin=`git rev-parse origin/web`
+
+if [ $head != $origin ]; then
+        git pull
+        pm2 reload app
+        cd /root/IssueTracker-19/frontend
+        npm run build
+fi
+echo 'finish!'

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const jsonHeader = { 'Content-Type': 'application/json;charset=utf-8' };
-const instance = axios.create();
+const instance = axios.create({ baseURL: 'http://localhost:3000', withCredentials: true });
 
 instance.interceptors.request.use(
   config => {

--- a/frontend/src/components/IssueList/IssueFilterTab/FilterBox/FilterBox.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/FilterBox/FilterBox.js
@@ -35,7 +35,7 @@ const Modal = styled.div`
   z-index: 2;
 `;
 
-export default function FilterBox({ items, name, title }) {
+export default function FilterBox({ name, title, children }) {
   const modal = useRef();
 
   const [visiable, setVisiable] = useState(false);
@@ -54,12 +54,9 @@ export default function FilterBox({ items, name, title }) {
         <ArrowImg src={downArrowIcon} />
       </FilterButton>
       <Modal tabIndex={0} ref={modal} onBlur={closeAuthorModal}>
-        <OptionSelectModal
-          visiable={visiable}
-          setVisiable={setVisiable}
-          title={title}
-          items={items}
-        />
+        <OptionSelectModal visiable={visiable} setVisiable={setVisiable} title={title}>
+          {children}
+        </OptionSelectModal>
       </Modal>
     </FilterContainer>
   );

--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -54,7 +54,6 @@ export default function IssueFilterTab({ setIssues, issues, allChecked, markMode
         milestoneService.getMilestones(),
       ]);
       setFilterList({ users, labels, milestones });
-      console.log('a', milestones);
     } catch (err) {
       if (err?.response?.status === 401) {
         history.push('/login');

--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -52,7 +52,11 @@ export default function IssueFilterTab({ setIssues, issues, allChecked, markMode
       <input type="checkbox" onChange={handleCheck} checked={allChecked} />
       <FilterList>
         {markMode ? (
-          <FilterBox name="Mark as" title="Actions"></FilterBox>
+          <FilterBox name="Mark as" title="Actions">
+            {['Open', 'Closed'].map((item, idx) => (
+              <ListItem key={idx + item}>{item}</ListItem>
+            ))}
+          </FilterBox>
         ) : (
           <>
             <FilterBox name="Author" title="Filter by author">

--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -84,7 +84,7 @@ export default function IssueFilterTab({ setIssues, issues, allChecked, markMode
               ))}
             </FilterBox>
             <FilterBox name="Label" title="Filter by label">
-              {[<ListItem>{'Unlabeled'}</ListItem>].concat(
+              {[<ListItem key={'Unlabeled'}>{'Unlabeled'}</ListItem>].concat(
                 labels.map(({ no, name, color }) => (
                   <ListItem key={no}>
                     <LabelIcon color={color} />
@@ -94,12 +94,12 @@ export default function IssueFilterTab({ setIssues, issues, allChecked, markMode
               )}
             </FilterBox>
             <FilterBox name="Milestones" title="Filter by milestone">
-              {[<ListItem>{'Issues with no milestone'}</ListItem>].concat(
+              {[<ListItem key={'no-milestone'}>{'Issues with no milestone'}</ListItem>].concat(
                 milestones.map(({ no, title }) => <ListItem key={no}>{title}</ListItem>),
               )}
             </FilterBox>
             <FilterBox name="Assignees" title={`Filter by who's assigned`}>
-              {[<ListItem>{'Assigned to nobody'}</ListItem>].concat(
+              {[<ListItem key={'nobody'}>{'Assigned to nobody'}</ListItem>].concat(
                 users.map(({ nickname }, idx) => (
                   <ListItem key={idx + nickname}>{nickname}</ListItem>
                 )),

--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { flex } from '@styles/utils';
-import { userService } from '@services';
+import { userService, labelService, milestoneService } from '@services';
 import FilterBox from './FilterBox/FilterBox';
-import { ListBox, ListItem } from '@components';
+import { ListItem } from '@components';
 
 const Container = styled.div`
   border: 1px solid gray;
@@ -12,6 +12,14 @@ const Container = styled.div`
 
 const FilterList = styled.div`
   ${flex()}
+`;
+
+const LabelIcon = styled.div`
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+  background-color: ${props => props.color};
 `;
 
 const filterState = {
@@ -34,12 +42,24 @@ export default function IssueFilterTab({ setIssues, issues, allChecked, markMode
         {
           data: { users },
         },
-      ] = await Promise.all([userService.getUsers()]);
-      setFilterList({ ...filterList, users });
-    } catch ({ response: { status } }) {
-      if (status === 401) {
+        {
+          data: { labels },
+        },
+        {
+          data: { milestones },
+        },
+      ] = await Promise.all([
+        userService.getUsers(),
+        labelService.getLabels(),
+        milestoneService.getMilestones(),
+      ]);
+      setFilterList({ users, labels, milestones });
+      console.log('a', milestones);
+    } catch (err) {
+      if (err?.response?.status === 401) {
         history.push('/login');
       }
+      console.error(err);
     }
   };
 
@@ -64,12 +84,27 @@ export default function IssueFilterTab({ setIssues, issues, allChecked, markMode
                 <ListItem key={idx + nickname}>{nickname}</ListItem>
               ))}
             </FilterBox>
-            <FilterBox name="Label" title="Filter by label"></FilterBox>
-            <FilterBox name="Milestones" title="Filter by milestone"></FilterBox>
+            <FilterBox name="Label" title="Filter by label">
+              {[<ListItem>{'Unlabeled'}</ListItem>].concat(
+                labels.map(({ no, name, color }) => (
+                  <ListItem key={no}>
+                    <LabelIcon color={color} />
+                    {name}
+                  </ListItem>
+                )),
+              )}
+            </FilterBox>
+            <FilterBox name="Milestones" title="Filter by milestone">
+              {[<ListItem>{'Issues with no milestone'}</ListItem>].concat(
+                milestones.map(({ no, title }) => <ListItem key={no}>{title}</ListItem>),
+              )}
+            </FilterBox>
             <FilterBox name="Assignees" title={`Filter by who's assigned`}>
-              {users.map(({ nickname }, idx) => (
-                <ListItem key={idx + nickname}>{nickname}</ListItem>
-              ))}
+              {[<ListItem>{'Assigned to nobody'}</ListItem>].concat(
+                users.map(({ nickname }, idx) => (
+                  <ListItem key={idx + nickname}>{nickname}</ListItem>
+                )),
+              )}
             </FilterBox>
           </>
         )}

--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { flex } from '@styles/utils';
 import { userService } from '@services';
 import FilterBox from './FilterBox/FilterBox';
+import { ListBox, ListItem } from '@components';
 
 const Container = styled.div`
   border: 1px solid gray;
@@ -19,7 +20,7 @@ const filterState = {
   milestones: [],
 };
 
-export default function IssueFilterTab({ setIssues, issues, allChecked }) {
+export default function IssueFilterTab({ setIssues, issues, allChecked, markMode }) {
   const handleCheck = ({ target: { checked } }) => {
     setIssues(issues.map(issue => ({ ...issue, checked })));
   };
@@ -50,10 +51,24 @@ export default function IssueFilterTab({ setIssues, issues, allChecked }) {
     <Container>
       <input type="checkbox" onChange={handleCheck} checked={allChecked} />
       <FilterList>
-        <FilterBox name="Author" title="Filter by author" items={users} />
-        <FilterBox name="Label" title="Filter by label" items={labels} />
-        <FilterBox name="Milestones" title="Filter by milestone" items={milestones} />
-        <FilterBox name="Assignees" title={`Filter by who's assigned`} items={users} />
+        {markMode ? (
+          <FilterBox name="Mark as" title="Actions"></FilterBox>
+        ) : (
+          <>
+            <FilterBox name="Author" title="Filter by author">
+              {users.map(({ nickname }, idx) => (
+                <ListItem key={idx + nickname}>{nickname}</ListItem>
+              ))}
+            </FilterBox>
+            <FilterBox name="Label" title="Filter by label"></FilterBox>
+            <FilterBox name="Milestones" title="Filter by milestone"></FilterBox>
+            <FilterBox name="Assignees" title={`Filter by who's assigned`}>
+              {users.map(({ nickname }, idx) => (
+                <ListItem key={idx + nickname}>{nickname}</ListItem>
+              ))}
+            </FilterBox>
+          </>
+        )}
       </FilterList>
     </Container>
   );

--- a/frontend/src/components/IssueList/IssueList.js
+++ b/frontend/src/components/IssueList/IssueList.js
@@ -5,9 +5,11 @@ import IssueItem from './IssueItem/IssueItem';
 import { useHistory } from 'react-router-dom';
 
 export default function IssueList() {
-  const [issues, setIssues] = useState([]);
   const history = useHistory();
+
+  const [issues, setIssues] = useState([]);
   const allChecked = issues.every(i => i.checked);
+  const markMode = issues.some(i => i.checked);
 
   const setFilterdIssues = async options => {
     try {
@@ -31,7 +33,12 @@ export default function IssueList() {
 
   return (
     <>
-      <IssueFilterTab issues={issues} setIssues={setIssues} allChecked={allChecked} />
+      <IssueFilterTab
+        issues={issues}
+        setIssues={setIssues}
+        allChecked={allChecked}
+        markMode={markMode}
+      />
       {issues.map(({ title, checked }, idx) => (
         <IssueItem
           key={idx}

--- a/frontend/src/components/IssueSearchBox/IssueSearchBox.js
+++ b/frontend/src/components/IssueSearchBox/IssueSearchBox.js
@@ -9,13 +9,13 @@ import downArrowIcon from '@imgs/down-arrow.svg';
 import mGlass from '@imgs/m-glass.svg';
 
 const SearchContainer = styled.div`
-  margin: 1.2rem 0;
+  margin-bottom: 1.4rem;
 `;
 
 const SearchBox = styled.div`
   width: 100%;
   height: 3rem;
-  padding: 0.5rem 0;
+  margin-bottom: 0.5rem;
   ${flex('space-between', 'center')}
 `;
 

--- a/frontend/src/components/OptionSelectModal/OptionSelectModal.js
+++ b/frontend/src/components/OptionSelectModal/OptionSelectModal.js
@@ -32,14 +32,14 @@ const ListBox = styled.div`
   overflow-y: scroll;
 `;
 
-const ListItem = styled.div`
+export const ListItem = styled.div`
   font-size: 0.8rem;
   padding: 0.5rem 0 0.5rem 0.7rem;
   border-bottom: 1px solid ${colors.lightGray};
   cursor: pointer;
 `;
 
-export default function OptionSelectModal({ visiable, setVisiable, title, items }) {
+export default function OptionSelectModal({ visiable, setVisiable, title, items, children }) {
   const handleClose = () => {
     setVisiable(false);
   };
@@ -52,12 +52,7 @@ export default function OptionSelectModal({ visiable, setVisiable, title, items 
             <span>{title}</span>
             <CloseImg src={closeDarkIcon} onClick={handleClose} />
           </Header>
-          {/* TODO 여기서 ListBox를 외부에서 주입받아야 함. Author, Label,.. 등등 각각의 값이 다름 */}
-          <ListBox>
-            {items.map(({ nickname }, idx) => (
-              <ListItem key={idx}>{nickname}</ListItem>
-            ))}
-          </ListBox>
+          <ListBox>{children}</ListBox>
         </Container>
       ) : null}
     </>

--- a/frontend/src/components/OptionSelectModal/OptionSelectModal.js
+++ b/frontend/src/components/OptionSelectModal/OptionSelectModal.js
@@ -29,7 +29,7 @@ const CloseImg = styled.img`
 
 const ListBox = styled.div`
   max-height: 20rem;
-  overflow-y: scroll;
+  overflow-y: auto;
 `;
 
 export const ListItem = styled.div`

--- a/frontend/src/components/OptionSelectModal/OptionSelectModal.js
+++ b/frontend/src/components/OptionSelectModal/OptionSelectModal.js
@@ -33,13 +33,14 @@ const ListBox = styled.div`
 `;
 
 export const ListItem = styled.div`
+  ${flex('flex-start', 'center')}
   font-size: 0.8rem;
   padding: 0.5rem 0 0.5rem 0.7rem;
   border-bottom: 1px solid ${colors.lightGray};
   cursor: pointer;
 `;
 
-export default function OptionSelectModal({ visiable, setVisiable, title, items, children }) {
+export default function OptionSelectModal({ visiable, setVisiable, title, children }) {
   const handleClose = () => {
     setVisiable(false);
   };

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -7,4 +7,4 @@ export { default as LabelMilestoneControls } from './LabelMilestoneControls/Labe
 export { default as LabelBox } from './LabelBox/LabelBox';
 export { default as MilestoneEditBox } from './MilestoneEditBox/MilestoneEditBox';
 export { default as MilestoneNewHeader } from './MilestoneNewHeader/MilestoneNewHeader';
-export { default as OptionSelectModal } from './OptionSelectModal/OptionSelectModal';
+export { default as OptionSelectModal, ListItem } from './OptionSelectModal/OptionSelectModal';

--- a/frontend/src/pages/Issue.js
+++ b/frontend/src/pages/Issue.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Header, IssueList, IssueSearchBox } from '@components';
+import { numerics } from '@styles/variables';
 
 const IssueContainer = styled.div`
-  width: calc(100% - 160px);
-  margin: 0 auto;
+  ${`width: calc(100% - ${numerics.marginHorizontal} * 2)`};
+  margin: ${numerics.marginHorizontal};
 `;
 
 export default function Issue() {

--- a/frontend/src/services/index.js
+++ b/frontend/src/services/index.js
@@ -1,2 +1,4 @@
 export { issueService } from './issue.service';
 export { userService } from './user.service';
+export { labelService } from './label.service';
+export { milestoneService } from './milestone.service';

--- a/frontend/src/services/label.service.js
+++ b/frontend/src/services/label.service.js
@@ -1,0 +1,7 @@
+import { API } from '@api';
+
+export const labelService = {
+  getLabels() {
+    return API.get('/api/labels');
+  },
+};

--- a/frontend/src/services/milestone.service.js
+++ b/frontend/src/services/milestone.service.js
@@ -1,0 +1,7 @@
+import { API } from '@api';
+
+export const milestoneService = {
+  getMilestones() {
+    return API.get('/api/milestones');
+  },
+};


### PR DESCRIPTION
## [구현 내용]

PR이 길어지면 리뷰가 힘들 것 같아서 미리 끊어서 보냅니다. 읽어보시고 머지해도 되겠다 싶으면 댓글로 알려주세요~

### 1. 배포 스크립트 작성 

### 2. axios baseUrl 변경 및 cors 옵션 변경
  - 지금은 백엔드 서버가 프론트 빌드 파일을 호스팅 하고 있어서 설정하지 않아도 되지만, 추후 nginx는 프론트에 연결하기 위해서 설정했습니다.
  - 혹시 이거 때문에 로그인 후 쿠키 저장이 안되는 문제가 생긴다면 바로 알려주세요!

### 3. OptionSelectModal을 확장가능하게 변경
  - OptionSelectModal의 ListBox 내부에 있는 ListItem을 export해주고, 밖에서 원하는 형식으로 완성해서 주입하도록 변경했습니다.   fd58381
  - IssueFilterTab.js 파일과 FilterBox.js 파일에서 사용하고 있으니 해당 코드를 참고해서 사용해주세요! 
  - 코드가 이해안가면 바로 물어보셔도 됩니다.

### 4. markMode 구현
  - 이슈 요소가 한 개라도 선택되면 필터 탭이 mark as로 변경됩니다. 해당 상태에서 이슈를 open, close할 수 있게 디자인만 해놓았습니다.
  ![image](https://user-images.githubusercontent.com/61396464/98358533-343d8000-206a-11eb-9d83-52102a820880.png)

### 5. 필터탭 추가 구현
  - labels, milestones도 불러와서 뜨도록 구현해놨습니다. 디자인만 살짝 손보면 될 것 같아요~
  ![image](https://user-images.githubusercontent.com/61396464/98358615-52a37b80-206a-11eb-860e-2a9b542cfd88.png)
  ![image](https://user-images.githubusercontent.com/61396464/98358637-5d5e1080-206a-11eb-8e9a-cc94f644d7c3.png)
