### PR TITLE
[Web-#92] 레이블 화면 완성

### DIFF
--- a/frontend/src/components/LabelBox/LabelBox.js
+++ b/frontend/src/components/LabelBox/LabelBox.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { flexColumn } from '@styles/utils';
 import { numerics } from '@styles/variables';
 import LabelItemBox from './LabelItemBox/LabelItemBox';
 import LabelMilestoneTab from './LabelMilestoneTab/LabelMilestoneTab';
+import { LabelBoxContext } from './LabelBoxContext';
 
 const Box = styled.div`
   flex: 1;
@@ -12,10 +13,23 @@ const Box = styled.div`
 `;
 
 export default function LabelBox() {
+  const [isAdding, setIsAdding] = useState(false);
+
+  const toggleIsAdding = () => {
+    setIsAdding(!isAdding);
+  };
+
   return (
-    <Box>
-      <LabelMilestoneTab />
-      <LabelItemBox />
-    </Box>
+    <LabelBoxContext.Provider
+      value={{
+        isAdding,
+        toggleIsAdding,
+      }}
+    >
+      <Box>
+        <LabelMilestoneTab />
+        <LabelItemBox />
+      </Box>
+    </LabelBoxContext.Provider>
   );
 }

--- a/frontend/src/components/LabelBox/LabelBoxContext.js
+++ b/frontend/src/components/LabelBox/LabelBoxContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const LabelBoxContext = createContext();

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
@@ -4,6 +4,7 @@ import { flex, flexColumn, calFontColor } from '@styles/utils';
 import { colors } from '@styles/variables';
 import { LabelTag } from '@components';
 import { SubmitButton, CancelButton } from '@shared';
+import { calcFontColor } from '@styles/utils';
 
 const Box = styled.div`
   ${flexColumn};
@@ -84,7 +85,7 @@ const svgConfig = styled.svg.attrs({
 
 // TODO : fill color adjust
 const ColorIcon = styled(svgConfig)`
-  fill: black;
+  fill: ${props => calcFontColor(props.backgroundColor)};
   width: 16px;
   height: 16px;
 `;
@@ -116,7 +117,7 @@ export default function LabelEditBox({
           <InputLabel>Color</InputLabel>
           <ItemBoxRow>
             <ColorButton backgroundColor={color}>
-              <ColorIcon fill={color}>
+              <ColorIcon backgroundColor={color}>
                 <path
                   fillRule="evenodd"
                   d="M8 2.5a5.487 5.487 0 00-4.131 1.869l1.204 1.204A.25.25 0 014.896 6H1.25A.25.25 0 011 5.75V2.104a.25.25 0 01.427-.177l1.38 1.38A7.001 7.001 0 0114.95 7.16a.75.75 0 11-1.49.178A5.501 5.501 0 008 2.5zM1.705 8.005a.75.75 0 01.834.656 5.501 5.501 0 009.592 2.97l-1.204-1.204a.25.25 0 01.177-.427h3.646a.25.25 0 01.25.25v3.646a.25.25 0 01-.427.177l-1.38-1.38A7.001 7.001 0 011.05 8.84a.75.75 0 01.656-.834z"

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { flex, flexColumn, calFontColor } from '@styles/utils';
 import { colors } from '@styles/variables';
 import { LabelTag } from '@components';
 import { SubmitButton, CancelButton } from '@shared';
-import { calcFontColor } from '@styles/utils';
+import { calcFontColor, pickRandomColor } from '@styles/utils';
 
 const Box = styled.div`
   ${flexColumn};
@@ -83,53 +83,64 @@ const svgConfig = styled.svg.attrs({
   ariaHideen: 'true',
 })``;
 
-// TODO : fill color adjust
 const ColorIcon = styled(svgConfig)`
   fill: ${props => calcFontColor(props.backgroundColor)};
   width: 16px;
   height: 16px;
 `;
 
-export default function LabelEditBox({
-  no = 1,
-  name = 'Label preview',
-  description,
-  color = '#246',
-}) {
+export default function LabelEditBox({ no = null, name = '', description = '', color = '#246' }) {
+  const [label, setLabel] = useState({ no, name, description, color });
+
+  const handleLabel = ({ target }) => {
+    const { name, value } = target;
+    setLabel({ ...label, [name]: value });
+  };
+
+  const handleColorButton = () => {
+    setLabel({ ...label, color: pickRandomColor() });
+  };
+
   return (
     <Box>
       <EditHeader>
         <ItemBox>
-          <LabelTag {...{ name, color }} />
+          <LabelTag name={label.name} color={label.color} />
         </ItemBox>
-        <ItemBox>{no ? <DeleteButton>Delete</DeleteButton> : null}</ItemBox>
+        <ItemBox>{label.no ? <DeleteButton>Delete</DeleteButton> : null}</ItemBox>
       </EditHeader>
       <EditBody>
         <ItemBox flexGrow={1}>
           <InputLabel>Label Name</InputLabel>
-          <InputBox />
+          <InputBox name="name" type="text" onChange={handleLabel} />
         </ItemBox>
         <ItemBox flexGrow={4}>
           <InputLabel>Description</InputLabel>
-          <InputBox />
+          <InputBox name="description" type="text" onChange={handleLabel} />
         </ItemBox>
         <ItemBox>
           <InputLabel>Color</InputLabel>
           <ItemBoxRow>
-            <ColorButton backgroundColor={color}>
-              <ColorIcon backgroundColor={color}>
+            <ColorButton backgroundColor={label.color} onClick={handleColorButton}>
+              <ColorIcon backgroundColor={label.color}>
                 <path
                   fillRule="evenodd"
                   d="M8 2.5a5.487 5.487 0 00-4.131 1.869l1.204 1.204A.25.25 0 014.896 6H1.25A.25.25 0 011 5.75V2.104a.25.25 0 01.427-.177l1.38 1.38A7.001 7.001 0 0114.95 7.16a.75.75 0 11-1.49.178A5.501 5.501 0 008 2.5zM1.705 8.005a.75.75 0 01.834.656 5.501 5.501 0 009.592 2.97l-1.204-1.204a.25.25 0 01.177-.427h3.646a.25.25 0 01.25.25v3.646a.25.25 0 01-.427.177l-1.38-1.38A7.001 7.001 0 011.05 8.84a.75.75 0 01.656-.834z"
                 ></path>
               </ColorIcon>
             </ColorButton>
-            <InputBox width={'5em'} />
+            <InputBox
+              width={'5em'}
+              name="color"
+              type="text"
+              onChange={handleLabel}
+              value={label.color}
+            />
           </ItemBoxRow>
         </ItemBox>
         <ItemBoxRow marginTop={true}>
           <CancelButton>Cancel</CancelButton>
-          <SubmitButton>{no ? 'Save changes' : 'Create Label'}</SubmitButton>
+          <SubmitButton>{label.no ? 'Save changes' : 'Create Label'}</SubmitButton>
         </ItemBoxRow>
       </EditBody>
     </Box>

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import { labelService } from '@services';
 import { flex, flexColumn, calFontColor } from '@styles/utils';
@@ -6,6 +6,7 @@ import { colors } from '@styles/variables';
 import { LabelTag } from '@components';
 import { SubmitButton, CancelButton } from '@shared';
 import { calcFontColor, pickRandomColor } from '@styles/utils';
+import { LabelBoxContext } from '@components/LabelBox/LabelBoxContext';
 
 const Box = styled.form`
   ${flexColumn};
@@ -100,6 +101,7 @@ export default function LabelEditBox({
   editingLabels,
 }) {
   const [label, setLabel] = useState({ no, name, description, color });
+  const { toggleIsAdding } = useContext(LabelBoxContext);
 
   const handleLabel = ({ target }) => {
     const { name, value } = target;
@@ -159,7 +161,7 @@ export default function LabelEditBox({
 
         // Success
         if (status === 201) {
-          handleCancel();
+          toggleIsAdding();
           reloadLabels();
         }
       } catch ({ response: { status } }) {
@@ -180,6 +182,7 @@ export default function LabelEditBox({
       setEditingLabels(new Set([...editingLabels].filter(labelID => labelID !== label.no)));
     } else {
       // Adding
+      toggleIsAdding();
     }
   };
 

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
@@ -95,6 +95,7 @@ export default function LabelEditBox({
   name = '',
   description = '',
   color = pickRandomColor(),
+  reloadLabels,
 }) {
   const [label, setLabel] = useState({ no, name, description, color });
 
@@ -123,6 +124,7 @@ export default function LabelEditBox({
 
         // Success
         if (status === 201) {
+          reloadLabels();
         }
       } catch ({ response: { status } }) {
         if (status === 500) {

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { labelService } from '@services';
 import { flex, flexColumn, calFontColor } from '@styles/utils';
 import { colors } from '@styles/variables';
 import { LabelTag } from '@components';
 import { SubmitButton, CancelButton } from '@shared';
 import { calcFontColor, pickRandomColor } from '@styles/utils';
 
-const Box = styled.div`
+const Box = styled.form`
   ${flexColumn};
   background-color: ${colors.lightestGray};
   padding: 1.5rem;
@@ -89,7 +90,12 @@ const ColorIcon = styled(svgConfig)`
   height: 16px;
 `;
 
-export default function LabelEditBox({ no = null, name = '', description = '', color = '#246' }) {
+export default function LabelEditBox({
+  no = null,
+  name = '',
+  description = '',
+  color = pickRandomColor(),
+}) {
   const [label, setLabel] = useState({ no, name, description, color });
 
   const handleLabel = ({ target }) => {
@@ -101,8 +107,39 @@ export default function LabelEditBox({ no = null, name = '', description = '', c
     setLabel({ ...label, color: pickRandomColor() });
   };
 
+  const handleSubmit = async e => {
+    e.preventDefault();
+
+    if (label.no) {
+      // Edit label
+    } else {
+      // Add label
+      try {
+        const { status } = await labelService.addLabel({
+          name: label.name,
+          description: label.description ? label.description : null,
+          color: label.color,
+        });
+
+        // Success
+        if (status === 201) {
+        }
+      } catch ({ response: { status } }) {
+        if (status === 500) {
+          alert('중복된 레이블 이름입니다');
+        }
+
+        if (status === 400) {
+          alert('올바르지 않은 입력 값 입니다');
+        }
+      }
+    }
+  };
+
+  const handleCancel = () => {};
+
   return (
-    <Box>
+    <Box onSubmit={handleSubmit}>
       <EditHeader>
         <ItemBox>
           <LabelTag name={label.name} color={label.color} />
@@ -112,7 +149,7 @@ export default function LabelEditBox({ no = null, name = '', description = '', c
       <EditBody>
         <ItemBox flexGrow={1}>
           <InputLabel>Label Name</InputLabel>
-          <InputBox name="name" type="text" onChange={handleLabel} />
+          <InputBox name="name" type="text" onChange={handleLabel} required />
         </ItemBox>
         <ItemBox flexGrow={4}>
           <InputLabel>Description</InputLabel>
@@ -121,7 +158,7 @@ export default function LabelEditBox({ no = null, name = '', description = '', c
         <ItemBox>
           <InputLabel>Color</InputLabel>
           <ItemBoxRow>
-            <ColorButton backgroundColor={label.color} onClick={handleColorButton}>
+            <ColorButton type="button" backgroundColor={label.color} onClick={handleColorButton}>
               <ColorIcon backgroundColor={label.color}>
                 <path
                   fillRule="evenodd"
@@ -139,7 +176,9 @@ export default function LabelEditBox({ no = null, name = '', description = '', c
           </ItemBoxRow>
         </ItemBox>
         <ItemBoxRow marginTop={true}>
-          <CancelButton>Cancel</CancelButton>
+          <CancelButton type="button" onClick={handleCancel}>
+            Cancel
+          </CancelButton>
           <SubmitButton>{label.no ? 'Save changes' : 'Create Label'}</SubmitButton>
         </ItemBoxRow>
       </EditBody>

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelItem/LabelItem.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelItem/LabelItem.js
@@ -32,8 +32,16 @@ const Button = styled.button`
   cursor: pointer;
 `;
 
-export default function LabelItem({ no, name, description, color, reloadLabels }) {
-  const handleDelete = async e => {
+export default function LabelItem({
+  no,
+  name,
+  description,
+  color,
+  reloadLabels,
+  setEditingLabels,
+  editingLabels,
+}) {
+  const handleDelete = async () => {
     if (!confirm(`${name} 레이블을 삭제 하시겠습니까?`)) return;
 
     try {
@@ -44,6 +52,10 @@ export default function LabelItem({ no, name, description, color, reloadLabels }
     } catch ({ response: { status } }) {}
   };
 
+  const handleSetEditing = () => {
+    setEditingLabels(new Set([...editingLabels, no]));
+  };
+
   return (
     <Box>
       <NameBox>
@@ -51,7 +63,7 @@ export default function LabelItem({ no, name, description, color, reloadLabels }
       </NameBox>
       <DescBox>{description}</DescBox>
       <ButtonBox>
-        <Button>Edit</Button>
+        <Button onClick={handleSetEditing}>Edit</Button>
         <Button onClick={handleDelete}>Delete</Button>
       </ButtonBox>
     </Box>

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelItem/LabelItem.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelItem/LabelItem.js
@@ -32,7 +32,7 @@ const Button = styled.button`
   cursor: pointer;
 `;
 
-export default function LabelItem({ no, name, description, color }) {
+export default function LabelItem({ no, name, description, color, reloadLabels }) {
   const handleDelete = async e => {
     if (!confirm(`${name} 레이블을 삭제 하시겠습니까?`)) return;
 
@@ -40,6 +40,7 @@ export default function LabelItem({ no, name, description, color }) {
       const { status } = await labelService.deleteLabel({
         no,
       });
+      reloadLabels();
     } catch ({ response: { status } }) {}
   };
 

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelItem/LabelItem.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelItem/LabelItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { labelService } from '@services';
 import { flex } from '@styles/utils';
 import { colors } from '@styles/variables';
 import { LabelTag } from '@components';
@@ -24,11 +24,25 @@ const ButtonBox = styled.div`
   justify-content: space-around;
 `;
 
-const CustomLink = styled(Link)`
+const Button = styled.button`
+  background-color: inherit;
   color: ${colors.black6};
+  border: none;
+  outline: none;
+  cursor: pointer;
 `;
 
 export default function LabelItem({ no, name, description, color }) {
+  const handleDelete = async e => {
+    if (!confirm(`${name} 레이블을 삭제 하시겠습니까?`)) return;
+
+    try {
+      const { status } = await labelService.deleteLabel({
+        no,
+      });
+    } catch ({ response: { status } }) {}
+  };
+
   return (
     <Box>
       <NameBox>
@@ -36,8 +50,8 @@ export default function LabelItem({ no, name, description, color }) {
       </NameBox>
       <DescBox>{description}</DescBox>
       <ButtonBox>
-        <CustomLink to="/">Edit</CustomLink>
-        <CustomLink to="/">Delete</CustomLink>
+        <Button>Edit</Button>
+        <Button onClick={handleDelete}>Delete</Button>
       </ButtonBox>
     </Box>
   );

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelItemBox.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelItemBox.js
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { API } from '@api';
 import styled from 'styled-components';
 import { colors } from '@styles/variables';
 import { flexColumn } from '@styles/utils';
 import LabelItem from './LabelItem/LabelItem';
 import LabelEditBox from './LabelEditBox/LabelEditBox';
+import { LabelBoxContext } from '@components/LabelBox/LabelBoxContext';
 
 const Box = styled.div`
   ${flexColumn};
@@ -38,8 +39,8 @@ const LabelHeader = styled.div`
 
 export default function LabelItemBox() {
   const [labels, setLabels] = useState([]);
-  const [newOpened, setNewOpened] = useState(true);
   const [editingLabels, setEditingLabels] = useState(new Set());
+  const { isAdding } = useContext(LabelBoxContext);
 
   const getLabels = async () => {
     try {
@@ -51,17 +52,13 @@ export default function LabelItemBox() {
     }
   };
 
-  const handleNewOpened = () => {
-    setNewOpened(!newOpened);
-  };
-
   useEffect(() => {
     getLabels();
   }, []);
 
   return (
     <Box>
-      {newOpened ? (
+      {isAdding ? (
         <TopBox>
           <LabelEditBox reloadLabels={getLabels} />
         </TopBox>

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelItemBox.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelItemBox.js
@@ -38,6 +38,8 @@ const LabelHeader = styled.div`
 
 export default function LabelItemBox() {
   const [labels, setLabels] = useState([]);
+  const [newOpened, setNewOpened] = useState(true);
+  const [editingLabels, setEditingLabels] = useState(new Set());
 
   const getLabels = async () => {
     try {
@@ -49,22 +51,47 @@ export default function LabelItemBox() {
     }
   };
 
+  const handleNewOpened = () => {
+    setNewOpened(!newOpened);
+  };
+
   useEffect(() => {
     getLabels();
   }, []);
 
   return (
     <Box>
-      <TopBox>
-        <LabelEditBox reloadLabels={getLabels} />
-      </TopBox>
+      {newOpened ? (
+        <TopBox>
+          <LabelEditBox reloadLabels={getLabels} />
+        </TopBox>
+      ) : null}
 
       <BottomBox>
         <LabelHeader>8 Labels</LabelHeader>
 
-        {labels.map(label => (
-          <LabelItem key={label.no} {...label} reloadLabels={getLabels} />
-        ))}
+        {labels.map(label => {
+          if (editingLabels.has(label.no))
+            return (
+              <LabelEditBox
+                key={label.no}
+                reloadLabels={getLabels}
+                {...label}
+                setEditingLabels={setEditingLabels}
+                editingLabels={editingLabels}
+              />
+            );
+          else
+            return (
+              <LabelItem
+                key={label.no}
+                {...label}
+                reloadLabels={getLabels}
+                setEditingLabels={setEditingLabels}
+                editingLabels={editingLabels}
+              />
+            );
+        })}
       </BottomBox>
     </Box>
   );

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelItemBox.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelItemBox.js
@@ -56,14 +56,14 @@ export default function LabelItemBox() {
   return (
     <Box>
       <TopBox>
-        <LabelEditBox />
+        <LabelEditBox reloadLabels={getLabels} />
       </TopBox>
 
       <BottomBox>
         <LabelHeader>8 Labels</LabelHeader>
 
         {labels.map(label => (
-          <LabelItem key={label.no} {...label} />
+          <LabelItem key={label.no} {...label} reloadLabels={getLabels} />
         ))}
       </BottomBox>
     </Box>

--- a/frontend/src/components/LabelBox/LabelMilestoneTab/LabelMilestoneTab.js
+++ b/frontend/src/components/LabelBox/LabelMilestoneTab/LabelMilestoneTab.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { flex } from '@styles/utils';
 import { SubmitButton } from '@shared';
 import { LabelMilestoneControls } from '@components';
+import { LabelBoxContext } from '@components/LabelBox/LabelBoxContext';
 
 const Box = styled.div`
   ${flex()};
@@ -10,10 +11,11 @@ const Box = styled.div`
 `;
 
 export default function LabelMilestoneTab() {
+  const { toggleIsAdding } = useContext(LabelBoxContext);
   return (
     <Box>
       <LabelMilestoneControls labelChecked={true} />
-      <SubmitButton>New Label</SubmitButton>
+      <SubmitButton onClick={toggleIsAdding}>New Label</SubmitButton>
     </Box>
   );
 }

--- a/frontend/src/components/LabelTag/LabelTag.js
+++ b/frontend/src/components/LabelTag/LabelTag.js
@@ -14,7 +14,7 @@ const Tag = styled.span`
 export default function LabelTag({ name, color, size = '1rem' }) {
   return (
     <Tag color={color} size={size}>
-      {name}
+      {name ? name : 'Label preview'}
     </Tag>
   );
 }

--- a/frontend/src/components/LabelTag/LabelTag.js
+++ b/frontend/src/components/LabelTag/LabelTag.js
@@ -5,11 +5,15 @@ import { calcFontColor } from '@styles/utils';
 const Tag = styled.span`
   padding: 0.25em 0.7em;
   border-radius: 999em;
+
+  background-color: ${props => props.color};
+  color: ${props => calcFontColor(props.color)};
+  font-size: ${props => props.size};
 `;
 
 export default function LabelTag({ name, color, size = '1rem' }) {
   return (
-    <Tag style={{ backgroundColor: color, color: calcFontColor(color), fontSize: size }}>
+    <Tag color={color} size={size}>
       {name}
     </Tag>
   );

--- a/frontend/src/components/LabelTag/LabelTag.js
+++ b/frontend/src/components/LabelTag/LabelTag.js
@@ -1,16 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-
-// 배경색에 따라서 글자색을 검은색 혹은 흰색을 결정
-const calcFontColor = backgroundColor => {
-  const d = document.createElement('div');
-  d.style.color = backgroundColor;
-  const [R, G, B] = d.style.color.match(/\d+/g).map(color => parseInt(color));
-
-  // https://stackoverflow.com/a/36888120
-  const luma = (0.299 * R + 0.587 * G + 0.114 * B) / 255;
-  return luma > 0.5 ? 'black' : 'white';
-};
+import { calcFontColor } from '@styles/utils';
 
 const Tag = styled.span`
   padding: 0.25em 0.7em;

--- a/frontend/src/services/label.service.js
+++ b/frontend/src/services/label.service.js
@@ -12,4 +12,8 @@ export const labelService = {
   editLabel({ no, name, description, color }) {
     return API.put(`/api/labels/${no}`, { name, description, color });
   },
+
+  deleteLabel({ no }) {
+    return API.delete(`/api/labels/${no}`);
+  },
 };

--- a/frontend/src/services/label.service.js
+++ b/frontend/src/services/label.service.js
@@ -4,4 +4,12 @@ export const labelService = {
   getLabels() {
     return API.get('/api/labels');
   },
+
+  addLabel({ name, description, color }) {
+    return API.post('/api/labels', { name, description, color });
+  },
+
+  editLabel({ no, name, description, color }) {
+    return API.put(`/api/labels/${no}`, { name, description, color });
+  },
 };

--- a/frontend/src/styles/utils.js
+++ b/frontend/src/styles/utils.js
@@ -25,3 +25,14 @@ export const borderNoneBox = css`
 export const skyblueBoxShadow = css`
   box-shadow: 0 0 0 3px #b3d1f3;
 `;
+
+// 배경색에 따라서 글자색을 검은색 혹은 흰색을 결정
+export const calcFontColor = backgroundColor => {
+  const d = document.createElement('div');
+  d.style.color = backgroundColor;
+  const [R, G, B] = d.style.color.match(/\d+/g).map(color => parseInt(color));
+
+  // https://stackoverflow.com/a/36888120
+  const luma = (0.299 * R + 0.587 * G + 0.114 * B) / 255;
+  return luma > 0.5 ? 'black' : 'white';
+};

--- a/frontend/src/styles/utils.js
+++ b/frontend/src/styles/utils.js
@@ -40,3 +40,8 @@ export const calcFontColor = backgroundColor => {
   const luma = (0.299 * R + 0.587 * G + 0.114 * B) / 255;
   return luma > 0.5 ? 'black' : 'white';
 };
+
+export const pickRandomColor = () => {
+  const hexString = Math.floor(Math.random() * 0xffffff).toString(16);
+  return ('#000000'.substr(0, 7 - hexString.length) + hexString).toUpperCase();
+};

--- a/frontend/src/styles/utils.js
+++ b/frontend/src/styles/utils.js
@@ -30,6 +30,10 @@ export const skyblueBoxShadow = css`
 export const calcFontColor = backgroundColor => {
   const d = document.createElement('div');
   d.style.color = backgroundColor;
+
+  // Invalid value
+  if (d.style.color === '') return 'black';
+
   const [R, G, B] = d.style.color.match(/\d+/g).map(color => parseInt(color));
 
   // https://stackoverflow.com/a/36888120


### PR DESCRIPTION
컴포넌트가 비대해진다는 뜻이 뭔지 알겠습니다...

거의 대부분은 props를 넘겨주는 방식으로 구현하고 난 다음에, 상단의 new 버튼만큼은 props를 쓰면 너무 복잡해지기에 context를 사용해서 구현했습니다.

이제 이 코드를 context와 같은 기능들을 통해 최적화 하고, 컴포넌트 파일을 나누는 등 리팩토링 할 예정입니다.

혹시 버그가 있으면 알려주세요. 모든 요구사항들이 동작해야 합니다

![image](https://user-images.githubusercontent.com/67293994/98681055-94ebf600-23a5-11eb-95ff-4c8bba1b74ed.png)

그리고 LabelMilestoneTab은 공통 컴포넌트를 사용해야 했으나, context 사용을 위해 일단 따로 label내의 파일을 사용했습니다