### PR TITLE
[WEB-#158] 이슈 생성화면의 사이드바 일부 구현

### DIFF
--- a/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
+++ b/frontend/src/components/IssueList/IssueFilterTab/IssueFilterTab.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { flex } from '@styles/utils';
 import { colors } from '@styles/variables';
 import FilterBox from './FilterBox/FilterBox';
-import { ListItem } from '@components';
+import { ListItem } from '@shared';
 import { IssueContext } from '@pages';
 import { issueService } from '@services';
 

--- a/frontend/src/components/IssueSearchBox/IssueSearchBox.js
+++ b/frontend/src/components/IssueSearchBox/IssueSearchBox.js
@@ -4,8 +4,8 @@ import { Link } from 'react-router-dom';
 import { IssueContext, initialFilterOptions } from '@pages';
 import { flex, flexCenter, borderNoneBox, skyblueBoxShadow } from '@styles/utils';
 import { colors } from '@styles/variables';
-import { SubmitButton } from '@shared';
-import { LabelMilestoneControls, OptionSelectModal, ListItem } from '@components';
+import { SubmitButton, ListItem } from '@shared';
+import { LabelMilestoneControls, OptionSelectModal } from '@components';
 import downArrowIcon from '@imgs/down-arrow.svg';
 import mGlass from '@imgs/m-glass.svg';
 

--- a/frontend/src/components/IssueSidebar/IssueSidebar.js
+++ b/frontend/src/components/IssueSidebar/IssueSidebar.js
@@ -90,7 +90,7 @@ const IconDesc = styled(EllipsisDiv)`
 `;
 
 export default function IssueSidebar(props) {
-  const { handleAssignToMe } = props;
+  const { handleAssignToMe, handleClickAssignee, handleClickLabel, handleClickMilestone } = props;
 
   const [modalItems, setModalItems] = useState({ users: [], labels: [], milestones: [] });
   const { users, labels, milestones } = modalItems;
@@ -154,10 +154,6 @@ export default function IssueSidebar(props) {
     fetchAllModalItems();
   }, []);
 
-  const handleClickAssignee = () => {};
-  const handleClickLabel = () => {};
-  const handleClickMilestone = () => {};
-
   return (
     <MainContainer>
       <AssigneeBox>
@@ -172,7 +168,9 @@ export default function IssueSidebar(props) {
               width={'19rem'}
             >
               {users.map(({ no, nickname }) => (
-                <ListItem key={no}>{nickname}</ListItem>
+                <ListItem key={no} onClick={handleClickAssignee}>
+                  {nickname}
+                </ListItem>
               ))}
             </OptionSelectModal>
           </Modal>
@@ -195,7 +193,7 @@ export default function IssueSidebar(props) {
               width={'19rem'}
             >
               {labels.map(({ no, name, color, description }) => (
-                <MyListItem key={no}>
+                <MyListItem key={no} onClick={handleClickLabel}>
                   <IconBox>
                     <LabelIcon color={color} />
                     <IconTitle>{name}</IconTitle>
@@ -223,7 +221,7 @@ export default function IssueSidebar(props) {
             >
               {console.log(milestones)}
               {milestones.map(({ no, title }) => (
-                <ListItem key={no}>
+                <ListItem key={no} onClick={handleClickMilestone}>
                   <IconTitle>{title}</IconTitle>
                 </ListItem>
               ))}

--- a/frontend/src/components/IssueSidebar/IssueSidebar.js
+++ b/frontend/src/components/IssueSidebar/IssueSidebar.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
+import { OptionSelectModal } from '@components';
 import { colors } from '@styles/variables';
 import { flex } from '@styles/utils';
 import GearIcon from './GearIcon/GearIcon';
@@ -30,6 +31,7 @@ const LabelBox = styled(Box)``;
 const MilestoneBox = styled(Box)``;
 
 const Header = styled.div`
+  position: relative;
   ${flex('space-between', 'center')}
   cursor: pointer;
   &:hover {
@@ -46,34 +48,98 @@ const Content = styled.div`
   padding: 0.8rem 0 0 0;
 `;
 
-const AssigneeButton = styled.span``;
+const AssignMySelfButton = styled.span``;
 
-export default function IssueSidebar() {
+const Modal = styled.div`
+  position: absolute;
+  top: 1.8rem;
+  right: 0;
+  outline: 0;
+  z-index: 2;
+`;
+
+export default function IssueSidebar(props) {
+  const { handleAssignToMe } = props;
+
+  const assigneeModalRef = useRef();
+  const labelModalRef = useRef();
+  const milestoneModalRef = useRef();
+
+  const [visiableAssigneeModal, setVisiableAssigneeModal] = useState(false);
+  const [visiableLabelModal, setVisiableLabelModal] = useState(false);
+  const [visiableMilestoneModal, setVisiableMilestoneModal] = useState(false);
+
+  const openAssigneeModal = () => {
+    setVisiableAssigneeModal(true);
+    assigneeModalRef.current.focus();
+  };
+
+  const closeAssigneeModal = () => setVisiableAssigneeModal(false);
+
+  const openLabelModal = () => {
+    setVisiableLabelModal(true);
+    labelModalRef.current.focus();
+  };
+
+  const closeLabelModal = () => setVisiableLabelModal(false);
+
+  const openMilestoneModal = () => {
+    setVisiableMilestoneModal(true);
+    milestoneModalRef.current.focus();
+  };
+
+  const closeMilestoneModal = () => setVisiableMilestoneModal(false);
+
   return (
     <MainContainer>
       <AssigneeBox>
-        <Header>
+        <Header onClick={openAssigneeModal}>
           Assignees
           <GearIcon fillColor={colors.black8} />
+          <Modal tabIndex={0} ref={assigneeModalRef} onBlur={closeAssigneeModal}>
+            <OptionSelectModal
+              visiable={visiableAssigneeModal}
+              setVisiable={setVisiableAssigneeModal}
+              title={'Assign up to 10 people to this issue'}
+              width={'19rem'}
+            ></OptionSelectModal>
+          </Modal>
         </Header>
         <Content>
-          No one—<AssigneeButton>assign yourself</AssigneeButton>
+          No one—<AssignMySelfButton onClick={handleAssignToMe}>assign yourself</AssignMySelfButton>
           <Line />
         </Content>
       </AssigneeBox>
+
       <LabelBox>
-        <Header>
+        <Header onClick={openLabelModal}>
           Labels
           <GearIcon fillColor={colors.black8} />
+          <Modal tabIndex={0} ref={labelModalRef} onBlur={closeLabelModal}>
+            <OptionSelectModal
+              visiable={visiableLabelModal}
+              setVisiable={setVisiableLabelModal}
+              title={'Apply labels to this issue'}
+              width={'19rem'}
+            ></OptionSelectModal>
+          </Modal>
         </Header>
         <Content>None yet</Content>
         <Line />
       </LabelBox>
 
       <MilestoneBox>
-        <Header>
+        <Header onClick={openMilestoneModal}>
           Milestone
           <GearIcon fillColor={colors.black8} />
+          <Modal tabIndex={0} ref={milestoneModalRef} onBlur={closeMilestoneModal}>
+            <OptionSelectModal
+              visiable={visiableMilestoneModal}
+              setVisiable={setVisiableMilestoneModal}
+              title={'Set milestone'}
+              width={'19rem'}
+            ></OptionSelectModal>
+          </Modal>
         </Header>
         <Content>None yet</Content>
         <Line />

--- a/frontend/src/components/IssueSidebar/IssueSidebar.js
+++ b/frontend/src/components/IssueSidebar/IssueSidebar.js
@@ -53,7 +53,12 @@ const Content = styled.div`
   padding: 0.8rem 0 0 0;
 `;
 
-const AssignMySelfButton = styled.span``;
+const AssignMySelfButton = styled.span`
+  cursor: pointer;
+  &:hover {
+    color: ${colors.resetFilterColor};
+  }
+`;
 
 const Modal = styled.div`
   position: absolute;
@@ -90,10 +95,17 @@ const IconDesc = styled(EllipsisDiv)`
 `;
 
 export default function IssueSidebar(props) {
-  const { handleAssignToMe, handleClickAssignee, handleClickLabel, handleClickMilestone } = props;
+  const {
+    assignees,
+    labels,
+    milestone,
+    handleAssignToMe,
+    handleClickAssignee,
+    handleClickLabel,
+    handleClickMilestone,
+  } = props;
 
   const [modalItems, setModalItems] = useState({ users: [], labels: [], milestones: [] });
-  const { users, labels, milestones } = modalItems;
 
   const assigneeModalRef = useRef();
   const labelModalRef = useRef();
@@ -104,6 +116,10 @@ export default function IssueSidebar(props) {
   const [visiableMilestoneModal, setVisiableMilestoneModal] = useState(false);
 
   const openAssigneeModal = () => {
+    if (assignees.length === 10) {
+      alert('assignee는 최대 10명까지만 할당할 수 있습니다.');
+      return;
+    }
     setVisiableAssigneeModal(true);
     assigneeModalRef.current.focus();
   };
@@ -167,16 +183,25 @@ export default function IssueSidebar(props) {
               title={'Assign up to 10 people to this issue'}
               width={'19rem'}
             >
-              {users.map(({ no, nickname }) => (
-                <ListItem key={no} onClick={handleClickAssignee}>
-                  {nickname}
-                </ListItem>
-              ))}
+              {modalItems.users
+                .filter(u => !assignees.some(a => a.no === u.no))
+                .map(({ no, nickname }) => (
+                  <ListItem key={no} onClick={e => handleClickAssignee(e, { no, nickname })}>
+                    {nickname}
+                  </ListItem>
+                ))}
             </OptionSelectModal>
           </Modal>
         </Header>
         <Content>
-          No one—<AssignMySelfButton onClick={handleAssignToMe}>assign yourself</AssignMySelfButton>
+          {assignees && assignees.length ? (
+            assignees.map(({ no, nickname }) => <div key={no}>{nickname}</div>)
+          ) : (
+            <div>
+              No one—
+              <AssignMySelfButton onClick={handleAssignToMe}>assign yourself</AssignMySelfButton>
+            </div>
+          )}
           <Line />
         </Content>
       </AssigneeBox>
@@ -192,7 +217,7 @@ export default function IssueSidebar(props) {
               title={'Apply labels to this issue'}
               width={'19rem'}
             >
-              {labels.map(({ no, name, color, description }) => (
+              {modalItems.labels.map(({ no, name, color, description }) => (
                 <MyListItem key={no} onClick={handleClickLabel}>
                   <IconBox>
                     <LabelIcon color={color} />
@@ -204,7 +229,7 @@ export default function IssueSidebar(props) {
             </OptionSelectModal>
           </Modal>
         </Header>
-        <Content>None yet</Content>
+        <Content>{labels && labels.length ? <div></div> : 'None yet'}</Content>
         <Line />
       </LabelBox>
 
@@ -219,8 +244,7 @@ export default function IssueSidebar(props) {
               title={'Set milestone'}
               width={'19rem'}
             >
-              {console.log(milestones)}
-              {milestones.map(({ no, title }) => (
+              {modalItems.milestones.map(({ no, title }) => (
                 <ListItem key={no} onClick={handleClickMilestone}>
                   <IconTitle>{title}</IconTitle>
                 </ListItem>
@@ -228,7 +252,7 @@ export default function IssueSidebar(props) {
             </OptionSelectModal>
           </Modal>
         </Header>
-        <Content>None yet</Content>
+        <Content>{milestone ? <div></div> : 'None yet'}</Content>
         <Line />
       </MilestoneBox>
     </MainContainer>

--- a/frontend/src/components/IssueSidebar/IssueSidebar.js
+++ b/frontend/src/components/IssueSidebar/IssueSidebar.js
@@ -217,19 +217,28 @@ export default function IssueSidebar(props) {
               title={'Apply labels to this issue'}
               width={'19rem'}
             >
-              {modalItems.labels.map(({ no, name, color, description }) => (
-                <MyListItem key={no} onClick={handleClickLabel}>
-                  <IconBox>
-                    <LabelIcon color={color} />
-                    <IconTitle>{name}</IconTitle>
-                  </IconBox>
-                  <IconDesc>{description}</IconDesc>
-                </MyListItem>
-              ))}
+              {modalItems.labels
+                .filter(labelItems => !labels.some(l => l.no === labelItems.no))
+                .map(({ no, name, color, description }) => (
+                  <MyListItem
+                    key={no}
+                    onClick={e => handleClickLabel(e, { no, name, color, description })}
+                  >
+                    <IconBox>
+                      <LabelIcon color={color} />
+                      <IconTitle>{name}</IconTitle>
+                    </IconBox>
+                    <IconDesc>{description}</IconDesc>
+                  </MyListItem>
+                ))}
             </OptionSelectModal>
           </Modal>
         </Header>
-        <Content>{labels && labels.length ? <div></div> : 'None yet'}</Content>
+        <Content>
+          {labels && labels.length
+            ? labels.map(({ no, name }) => <div key={no}>{name}</div>)
+            : 'None yet'}
+        </Content>
         <Line />
       </LabelBox>
 
@@ -244,15 +253,17 @@ export default function IssueSidebar(props) {
               title={'Set milestone'}
               width={'19rem'}
             >
-              {modalItems.milestones.map(({ no, title }) => (
-                <ListItem key={no} onClick={handleClickMilestone}>
-                  <IconTitle>{title}</IconTitle>
-                </ListItem>
-              ))}
+              {modalItems.milestones
+                .filter(m => m.no !== milestone?.no)
+                .map(({ no, title }) => (
+                  <ListItem key={no} onClick={e => handleClickMilestone(e, { no, title })}>
+                    <IconTitle>{title}</IconTitle>
+                  </ListItem>
+                ))}
             </OptionSelectModal>
           </Modal>
         </Header>
-        <Content>{milestone ? <div></div> : 'None yet'}</Content>
+        <Content>{milestone ? <div>{milestone.title}</div> : 'None yet'}</Content>
         <Line />
       </MilestoneBox>
     </MainContainer>

--- a/frontend/src/components/LabelMilestoneTab/LabelMilestoneTab.js
+++ b/frontend/src/components/LabelMilestoneTab/LabelMilestoneTab.js
@@ -16,9 +16,9 @@ export default function LabelMilestoneTab({ submit, buttonName }) {
     <Box>
       <LabelMilestoneControls milestoneChecked={true} />
 
-      {Submit ? (
-        <Link to="milestones/new">
-          <SubmitButton>{ButtonName}</SubmitButton>
+      {submit ? (
+        <Link to="/milestones/new">
+          <SubmitButton>{buttonName}</SubmitButton>
         </Link>
       ) : null}
     </Box>

--- a/frontend/src/components/OptionSelectModal/OptionSelectModal.js
+++ b/frontend/src/components/OptionSelectModal/OptionSelectModal.js
@@ -41,7 +41,8 @@ export const ListItem = styled.div`
 `;
 
 export default function OptionSelectModal({ visiable, setVisiable, title, children }) {
-  const handleClose = () => {
+  const handleClose = e => {
+    e.stopPropagation();
     setVisiable(false);
   };
 

--- a/frontend/src/components/OptionSelectModal/OptionSelectModal.js
+++ b/frontend/src/components/OptionSelectModal/OptionSelectModal.js
@@ -5,7 +5,7 @@ import closeDarkIcon from '@imgs/close-dark.svg';
 import { flex } from '@styles/utils';
 
 const Container = styled.div`
-  width: 18.5rem;
+  width: ${props => (props.width ? props.width : '18.5rem')};
   border: 1px solid ${colors.lightGray};
   border-radius: 5px;
   background-color: white;
@@ -40,7 +40,7 @@ export const ListItem = styled.div`
   cursor: pointer;
 `;
 
-export default function OptionSelectModal({ visiable, setVisiable, title, children }) {
+export default function OptionSelectModal({ visiable, setVisiable, title, children, width }) {
   const handleClose = e => {
     e.stopPropagation();
     setVisiable(false);
@@ -49,7 +49,7 @@ export default function OptionSelectModal({ visiable, setVisiable, title, childr
   return (
     <>
       {visiable ? (
-        <Container>
+        <Container width={width}>
           <Header>
             <span>{title}</span>
             <CloseImg src={closeDarkIcon} onClick={handleClose} />

--- a/frontend/src/components/OptionSelectModal/OptionSelectModal.js
+++ b/frontend/src/components/OptionSelectModal/OptionSelectModal.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { colors } from '@styles/variables';
 import closeDarkIcon from '@imgs/close-dark.svg';
 import { flex } from '@styles/utils';
+import { ListItem } from '@shared';
 
 const Container = styled.div`
   width: ${props => (props.width ? props.width : '18.5rem')};
@@ -30,14 +31,6 @@ const CloseImg = styled.img`
 const ListBox = styled.div`
   max-height: 20rem;
   overflow-y: auto;
-`;
-
-export const ListItem = styled.div`
-  ${flex('flex-start', 'center')}
-  font-size: 0.8rem;
-  padding: 0.5rem 0 0.5rem 0.7rem;
-  border-bottom: 1px solid ${colors.lightGray};
-  cursor: pointer;
 `;
 
 export default function OptionSelectModal({ visiable, setVisiable, title, children, width }) {

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -10,6 +10,6 @@ export { default as LabelBox } from './LabelBox/LabelBox';
 export { default as MilestoneEditBox } from './MilestoneEditBox/MilestoneEditBox';
 export { default as MilestoneNewHeader } from './MilestoneNewHeader/MilestoneNewHeader';
 export { default as LabelMilestoneTab } from './LabelMilestoneTab/LabelMilestoneTab';
-export { default as OptionSelectModal, ListItem } from './OptionSelectModal/OptionSelectModal';
+export { default as OptionSelectModal } from './OptionSelectModal/OptionSelectModal';
 export { default as LabelTag } from './LabelTag/LabelTag';
 export { default as MilestoneList } from './MilestoneList/MilestoneList';

--- a/frontend/src/hoc/withAuth.js
+++ b/frontend/src/hoc/withAuth.js
@@ -1,14 +1,18 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { userService } from '@services';
 import { useHistory } from 'react-router-dom';
 
 export default function withAuth(InnerComponent) {
   return function WrapperComponent() {
     const history = useHistory();
+    const [user, setUser] = useState(null);
 
     const checkLogin = async () => {
       try {
         const { data, status } = await userService.checkLogin();
+        if (status === 200) {
+          setUser(data.user);
+        }
       } catch (err) {
         history.push('/login');
       }
@@ -18,6 +22,6 @@ export default function withAuth(InnerComponent) {
       checkLogin();
     }, []);
 
-    return <InnerComponent />;
+    return <InnerComponent user={user} />;
   };
 }

--- a/frontend/src/pages/IssueNew.js
+++ b/frontend/src/pages/IssueNew.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Header, IssueInputBox, IssueSidebar } from '@components';
 import styled from 'styled-components';
 import { numerics } from '@styles/variables';
@@ -9,9 +9,18 @@ const IssueContainer = styled.div`
   display: flex;
 `;
 
-export default function IssueNew() {
-  const handleAssignToMe = () => {};
-  const handleClickAssignee = () => {};
+export default function IssueNew({ user }) {
+  const [assignees, setAssignees] = useState([]);
+  const [labels, setLabels] = useState([]);
+  const [milestone, setMilestone] = useState(undefined);
+
+  const handleAssignToMe = () => {
+    const { no, nickname } = user;
+    setAssignees([{ no, nickname }]);
+  };
+  const handleClickAssignee = (e, user) => {
+    setAssignees([...assignees, user]);
+  };
   const handleClickLabel = () => {};
   const handleClickMilestone = () => {};
   return (
@@ -20,6 +29,9 @@ export default function IssueNew() {
       <IssueContainer>
         <IssueInputBox />
         <IssueSidebar
+          assignees={assignees}
+          labels={labels}
+          milestone={milestone}
           handleAssignToMe={handleAssignToMe}
           handleClickAssignee={handleClickAssignee}
           handleClickLabel={handleClickLabel}

--- a/frontend/src/pages/IssueNew.js
+++ b/frontend/src/pages/IssueNew.js
@@ -18,11 +18,19 @@ export default function IssueNew({ user }) {
     const { no, nickname } = user;
     setAssignees([{ no, nickname }]);
   };
+
   const handleClickAssignee = (e, user) => {
     setAssignees([...assignees, user]);
   };
-  const handleClickLabel = () => {};
-  const handleClickMilestone = () => {};
+
+  const handleClickLabel = (e, label) => {
+    setLabels([...labels, label]);
+  };
+
+  const handleClickMilestone = (e, newMilestone) => {
+    setMilestone(newMilestone);
+  };
+
   return (
     <>
       <Header />

--- a/frontend/src/pages/IssueNew.js
+++ b/frontend/src/pages/IssueNew.js
@@ -10,12 +10,21 @@ const IssueContainer = styled.div`
 `;
 
 export default function IssueNew() {
+  const handleAssignToMe = () => {};
+  const handleClickAssignee = () => {};
+  const handleClickLabel = () => {};
+  const handleClickMilestone = () => {};
   return (
     <>
       <Header />
       <IssueContainer>
         <IssueInputBox />
-        <IssueSidebar />
+        <IssueSidebar
+          handleAssignToMe={handleAssignToMe}
+          handleClickAssignee={handleClickAssignee}
+          handleClickLabel={handleClickLabel}
+          handleClickMilestone={handleClickMilestone}
+        />
       </IssueContainer>
     </>
   );

--- a/frontend/src/styles/shared/Box.js
+++ b/frontend/src/styles/shared/Box.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import { flex } from '@styles/utils';
+import { colors } from '@styles/variables';
+
+export const ListItem = styled.div`
+  ${flex('flex-start', 'center')}
+  font-size: 0.8rem;
+  padding: 0.5rem 0 0.5rem 0.7rem;
+  border-bottom: 1px solid ${colors.lightGray};
+  cursor: pointer;
+`;

--- a/frontend/src/styles/shared/Icon.js
+++ b/frontend/src/styles/shared/Icon.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const LabelIcon = styled.div`
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+  background-color: ${props => props.color};
+`;

--- a/frontend/src/styles/shared/index.js
+++ b/frontend/src/styles/shared/index.js
@@ -1,1 +1,3 @@
 export * from './Button';
+export * from './Icon';
+export * from './Box';


### PR DESCRIPTION
## [구현 내용]

### 1. OptionSelectModal 안에 들어갈 ListItem 구현 완료
 - 사이드 바의 OptionSelectModal 안에 들어갈 아이템들을 구현 했습니다.
  ![image](https://user-images.githubusercontent.com/61396464/98707186-19993d00-23c3-11eb-9cd9-17cd3d15de96.png)

### 2. withAuth에서 페이지 안에 user 정보 주입하도록 구현
- 55f4215

### 3. 사이드 바에서 선택한 assignees, labels, miestone을 화면에 나오게 하는 것 까지 구현
- (참고) 이슈 상세보기 페이지에서 해당 컴포넌트 재사용을 위해서 아이템 클릭 핸들러를 외부로 분리하고, 주입받아서 쓰는 형태로 구현했습니다.
  ![image](https://user-images.githubusercontent.com/61396464/98707205-1f8f1e00-23c3-11eb-8c72-ab6e86ba4b49.png)

### 4. 몇 가지 styled컴포넌트를 shared에 추가했습니다. 
- OptionSelectModal에 주입할 ListItem 컴포넌트를 shared로 분리했습니다.
- 그 외 필요한 컴포넌트를 shared로 분리했습니다.

---