### PR TITLE
[WEB-#91] 마일스톤 수정, 삭제 구현

### DIFF
--- a/backend/models/milestone.model.js
+++ b/backend/models/milestone.model.js
@@ -8,7 +8,8 @@ export const milestoneModel = {
       FROM milestone AS M 
       LEFT OUTER JOIN issue AS I 
       ON M.no=I.milestone_no 
-      GROUP BY M.no;`;
+      GROUP BY M.no
+      HAVING M.is_deleted=0;`;
     return pool.query(sql);
   },
   getMilestone({ no }) {
@@ -38,6 +39,10 @@ export const milestoneModel = {
   },
   deleteMilestone({ no }) {
     const sql = 'UPDATE milestone SET is_deleted=1 WHERE no=?;';
+    return pool.execute(sql, [no]);
+  },
+  deleteIssueMilestone({ no }) {
+    const sql = 'UPDATE issue SET milestone_no=NULL WHERE milestone_no=?;';
     return pool.execute(sql, [no]);
   },
   openMilestone({ no }) {

--- a/backend/routes/api/milestones/milestones.controller.js
+++ b/backend/routes/api/milestones/milestones.controller.js
@@ -69,6 +69,7 @@ export const deleteMilestone = async (req, res, next) => {
   try {
     const { no } = req.params;
     await milestoneModel.deleteMilestone({ no });
+    await milestoneModel.deleteIssueMilestone({ no });
     res.status(200).end();
   } catch (err) {
     next(err);

--- a/frontend/src/components/LabelMilestoneTab/LabelMilestoneTab.js
+++ b/frontend/src/components/LabelMilestoneTab/LabelMilestoneTab.js
@@ -16,9 +16,9 @@ export default function LabelMilestoneTab({ submit, buttonName }) {
     <Box>
       <LabelMilestoneControls milestoneChecked={true} />
 
-      {Submit ? (
+      {submit ? (
         <Link to="milestones/new">
-          <SubmitButton>{ButtonName}</SubmitButton>
+          <SubmitButton>{buttonName}</SubmitButton>
         </Link>
       ) : null}
     </Box>

--- a/frontend/src/components/MilestoneEditBox/MilestoneEditBox.js
+++ b/frontend/src/components/MilestoneEditBox/MilestoneEditBox.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { API } from '@api';
 import { flexColumn, flexCenter, flex } from '@styles/utils';
 import { SubmitButton, CancelButton } from '@shared';
 import { colors } from '@styles/variables';
+import { milestoneService } from '../../services/milestone.service';
+import { useHistory, useLocation } from 'react-router-dom';
 
 const Form = styled.form`
   width: 100%;
@@ -55,20 +56,69 @@ const ButtonSpace = styled.div`
   margin-left: 7px;
 `;
 export default function MilestoneEditBox({ isNew }) {
+  const [form, setForm] = useState({ title: ' ', dueDate: null, description: '' });
+  const { title, dueDate, description } = form;
+
+  const history = useHistory();
+  const location = useLocation();
+  const handleChange = ({ target }) => {
+    const { name, value } = target;
+    setForm({ ...form, [name]: value });
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    try {
+      if (dueDate === '') setForm({ ...form, dueDate: null });
+      const { data, status } = await milestoneService.addMilestones({
+        title,
+        dueDate,
+        description,
+      });
+      if (status === 201) {
+        history.push('/milestones');
+        return;
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
-    <Form>
+    <Form onSubmit={handleSubmit}>
       <Container>
         <InputBox>
           <Label htmlFor="milestone_title">Title</Label>
-          <Input type="text" id="milestone_title" placeholder="Title" />
+          <Input
+            type="text"
+            name="title"
+            onChange={handleChange}
+            id="milestone_title"
+            placeholder="Title"
+            value={location.state ? location.state.title : ''}
+            required
+          />
         </InputBox>
         <InputBox>
           <Label htmlFor="milestone_date">Due date (Optional)</Label>
-          <Input type="date" id="milestone_date" placeholder="yyyy-mm-dd" />
+          <Input
+            type="date"
+            name="dueDate"
+            onChange={handleChange}
+            id="milestone_date"
+            placeholder="yyyy-mm-dd"
+            value={location.state ? location.state.dueDate : ''}
+          />
         </InputBox>
         <InputBox>
           <Label htmlFor="milestone_description">Description</Label>
-          <Textarea cols="40" rows="20" />
+          <Textarea
+            name="description"
+            onChange={handleChange}
+            cols="40"
+            rows="20"
+            value={location.state ? location.state.description : ''}
+          />
         </InputBox>
       </Container>
       <SubmitBox>

--- a/frontend/src/components/MilestoneList/MilestoneItem/MilestoneItem.js
+++ b/frontend/src/components/MilestoneList/MilestoneItem/MilestoneItem.js
@@ -154,8 +154,8 @@ export default function MilestoneItem({
         no,
         isClosed,
         title,
-        dueDate: dueDate ? dueDate : '',
-        description: description ? description : '',
+        dueDate,
+        description,
       },
     });
   };

--- a/frontend/src/components/MilestoneList/MilestoneItem/MilestoneItem.js
+++ b/frontend/src/components/MilestoneList/MilestoneItem/MilestoneItem.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { colors } from '@styles/variables';
 import CalenderIcon from '@imgs/milestone-calendar.svg';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { milestoneService } from '@services';
 const Container = styled.div`
   width: 100%;
@@ -38,11 +38,11 @@ const Img = styled.img`
   width: 16px;
   height: 16px;
   margin-right: 4px;
-  padding-top: 3px;
 `;
 const Description = styled.div`
   font-size: 16px;
   color: ${colors.metaColor};
+  white-space: pre-wrap;
 `;
 const ProgressBox = styled.div`
   display: table-cell;
@@ -56,6 +56,7 @@ const ProgressBox = styled.div`
 const ProgressBar = styled.progress`
   height: 20px;
   width: 420px;
+  color: ${colors.submitColor};
 `;
 const Status = styled.div`
   display: inline-block;
@@ -79,6 +80,7 @@ const StatusEdit = styled.span`
   margin-right: 1rem;
   color: ${colors.checkedColor};
   text-decoration: none;
+  cursor: pointer;
 `;
 const StatusForm = styled.form`
   display: inline-block;
@@ -96,6 +98,12 @@ const CloseButton = styled(StatusButton)`
 const DeleteButton = styled(StatusButton)`
   color: #cb2431;
 `;
+const DueDate = styled.p`
+  display: flex;
+  align-items: center;
+  margin-top: 3px;
+  margin-bottom: 3px;
+`;
 export default function MilestoneItem({
   no,
   title,
@@ -103,7 +111,11 @@ export default function MilestoneItem({
   description,
   totalTasks,
   closedTasks,
+  isClosed,
 }) {
+  const [closed, setClosed] = useState(isClosed);
+  const [isDeleted, setIsDeleted] = useState(false);
+  const history = useHistory();
   const percentage = totalTasks === 0 ? 0 : Math.floor((closedTasks / totalTasks) * 100);
   const monthNames = [
     'January',
@@ -121,51 +133,78 @@ export default function MilestoneItem({
   ];
   const date = new Date(dueDate);
   const handleClose = async () => {
-    console.log(no);
     milestoneService.closeMilestones(no);
+    setClosed(true);
   };
-  return (
-    <Container>
-      <Title>
-        <TitleHeader>{title}</TitleHeader>
-        <Meta>
-          <MetaItem>
-            <Img src={CalenderIcon} />
-            Due by {monthNames[date.getMonth()]} {date.getDate()}, {date.getFullYear()}
-          </MetaItem>
-          <Description>
-            <p>{description}</p>
-          </Description>
-        </Meta>
-      </Title>
-      <ProgressBox>
-        <ProgressBar max="100" value={percentage}></ProgressBar>
-        <div>
-          <Status>
-            <span>{percentage}%</span>
-            <Label>complete</Label>
-          </Status>
-          <Status>
-            <span>{totalTasks - closedTasks}</span>
-            <Label>open</Label>
-          </Status>
-          <Status>
-            <span>{closedTasks}</span>
-            <Label>closed</Label>
-          </Status>
-        </div>
-        <StatusButtonBox>
-          <Link to="/milestones/:no">
-            <StatusEdit>Edit</StatusEdit>
-          </Link>
-          <StatusForm>
-            <CloseButton onClick={handleClose}>Close</CloseButton>
-          </StatusForm>
-          <StatusForm>
-            <DeleteButton>Delete</DeleteButton>
-          </StatusForm>
-        </StatusButtonBox>
-      </ProgressBox>
-    </Container>
-  );
+  const handleOpen = async () => {
+    milestoneService.openMilestones(no);
+    setClosed(false);
+  };
+  const handleDelete = async () => {
+    if (confirm(`[${title}] 마일스톤을 삭제하시겠습니까?`)) {
+      milestoneService.deleteMilestones(no);
+      setIsDeleted(true);
+    }
+  };
+  const handleClickEdit = () => {
+    const editLink = `/milestones/${no}/edit`;
+    history.push({
+      pathname: editLink,
+      state: { no, title, dueDate, description },
+    });
+  };
+  if (!isDeleted)
+    return (
+      <Container>
+        <Title>
+          <TitleHeader>{title}</TitleHeader>
+          <Meta>
+            <MetaItem>
+              {dueDate ? (
+                <DueDate>
+                  <Img src={CalenderIcon} />
+                  Due by {monthNames[date.getMonth()]} {date.getDate()}, {date.getFullYear()}
+                </DueDate>
+              ) : (
+                <DueDate>No due date</DueDate>
+              )}
+            </MetaItem>
+            <Description>
+              <p>{description ? description : ' '}</p>
+            </Description>
+          </Meta>
+        </Title>
+        <ProgressBox>
+          <ProgressBar max="100" value={percentage}></ProgressBar>
+          <div>
+            <Status>
+              <span>{percentage}%</span>
+              <Label>complete</Label>
+            </Status>
+            <Status>
+              <span>{totalTasks - closedTasks}</span>
+              <Label>open</Label>
+            </Status>
+            <Status>
+              <span>{closedTasks}</span>
+              <Label>closed</Label>
+            </Status>
+          </div>
+          <StatusButtonBox>
+            <StatusEdit onClick={handleClickEdit}>Edit</StatusEdit>
+            <StatusForm>
+              {!closed ? (
+                <CloseButton onClick={handleClose}>Close</CloseButton>
+              ) : (
+                <CloseButton onClick={handleOpen}>Open</CloseButton>
+              )}
+            </StatusForm>
+            <StatusForm>
+              <DeleteButton onClick={handleDelete}>Delete</DeleteButton>
+            </StatusForm>
+          </StatusButtonBox>
+        </ProgressBox>
+      </Container>
+    );
+  else return null;
 }

--- a/frontend/src/components/MilestoneList/MilestoneItem/MilestoneItem.js
+++ b/frontend/src/components/MilestoneList/MilestoneItem/MilestoneItem.js
@@ -133,7 +133,7 @@ export default function MilestoneItem({
   ];
   const date = new Date(dueDate);
   const handleClose = async () => {
-    milestoneService.closeMilestones(no);
+    await milestoneService.closeMilestones(no);
     setClosed(true);
   };
   const handleOpen = async () => {
@@ -150,9 +150,16 @@ export default function MilestoneItem({
     const editLink = `/milestones/${no}/edit`;
     history.push({
       pathname: editLink,
-      state: { no, title, dueDate, description },
+      state: {
+        no,
+        isClosed,
+        title,
+        dueDate: dueDate ? dueDate : '',
+        description: description ? description : '',
+      },
     });
   };
+  let showDesription = description ? description.split('\n')[0] : ' ';
   if (!isDeleted)
     return (
       <Container>
@@ -170,7 +177,7 @@ export default function MilestoneItem({
               )}
             </MetaItem>
             <Description>
-              <p>{description ? description : ' '}</p>
+              <p>{showDesription}</p>
             </Description>
           </Meta>
         </Title>

--- a/frontend/src/components/MilestoneList/MilestoneList.js
+++ b/frontend/src/components/MilestoneList/MilestoneList.js
@@ -36,7 +36,6 @@ export default function MilestoneList() {
   useEffect(() => {
     fetchMilestones();
   }, []);
-  console.log(milestoneList);
   return (
     <MilestoneListBox>
       <MilestoneHeader openCount={count.open} closeCount={count.closed} />

--- a/frontend/src/components/MilestoneList/MilestoneList.js
+++ b/frontend/src/components/MilestoneList/MilestoneList.js
@@ -36,12 +36,21 @@ export default function MilestoneList() {
   useEffect(() => {
     fetchMilestones();
   }, []);
-
+  console.log(milestoneList);
   return (
     <MilestoneListBox>
       <MilestoneHeader openCount={count.open} closeCount={count.closed} />
       {milestoneList.map(milestone => {
-        const { no, title, dueDate, description, totalTasks, closedTasks, isDeleted } = milestone;
+        const {
+          no,
+          title,
+          dueDate,
+          description,
+          totalTasks,
+          closedTasks,
+          isDeleted,
+          isClosed,
+        } = milestone;
         if (!isDeleted) {
           return (
             <MilestoneItem
@@ -52,6 +61,7 @@ export default function MilestoneList() {
               description={description}
               totalTasks={totalTasks}
               closedTasks={closedTasks}
+              isClosed={isClosed}
             />
           );
         }

--- a/frontend/src/pages/Milestone.js
+++ b/frontend/src/pages/Milestone.js
@@ -12,7 +12,7 @@ export default function Milestone() {
     <>
       <Header />
       <Container>
-        <LabelMilestoneTab Submit={true} ButtonName={'New milestone'} />
+        <LabelMilestoneTab submit={true} buttonName={'New milestone'} />
         <MilestoneList />
       </Container>
     </>

--- a/frontend/src/services/milestone.service.js
+++ b/frontend/src/services/milestone.service.js
@@ -7,4 +7,13 @@ export const milestoneService = {
   closeMilestones(no) {
     return API.patch(`/api/milestones/${no}/close`);
   },
+  openMilestones(no) {
+    return API.patch(`/api/milestones/${no}/open`);
+  },
+  deleteMilestones(no) {
+    return API.delete(`/api/milestones/${no}`);
+  },
+  addMilestones({ title, dueDate, description }) {
+    return API.post('/api/milestones', { title, dueDate, description });
+  },
 };

--- a/frontend/src/services/milestone.service.js
+++ b/frontend/src/services/milestone.service.js
@@ -16,4 +16,7 @@ export const milestoneService = {
   addMilestones({ title, dueDate, description }) {
     return API.post('/api/milestones', { title, dueDate, description });
   },
+  editMilestones({ no, title, dueDate, description }) {
+    return API.put(`/api/milestones/${no}`, { title, description, dueDate });
+  },
 };


### PR DESCRIPTION
## 스크린샷
![image](https://user-images.githubusercontent.com/37579982/98713220-a98eb500-23ca-11eb-97eb-471bf68c65b6.png)     
## 백엔드 API 변경 사항
- 마일스톤 리스트 가져올 때 삭제된 것은 제외하고 가져오도록 수정하였습니다.
## 해결?해야할것
- description이 여러 줄인 경우 원래 깃헙에서는 리스트에는 한줄만 표시하고 상세 페이지에서 나머지를 볼 수 있도록 되어있는데 이번 프로젝트의 경우 상세페이지가 없어서 나머지를 보려면 edit버튼을 누르는 방법밖에 없습니다. 우선 여러줄일 때 한줄만 보이도록 해놓긴 했는데 그냥 이렇게 놔두는게 좋을까요,,,?
- 리스트에서 바로 close, open을 하는 경우 상단 헤더에 바로 close갯수가 반영이 되어야하는데 아직 그부분 처리를 하지 못했습니다.
- open, close를 각각 버튼 클릭했을 때 해당하는 것만 보여주도록 하려고 하는데 아직 못했습니당,,,,
- 코드가 정말 많이 더럽습니다,,,,,,,,🤦🏻‍♀️