### PR TITLE
[WEB] progressBar 변경 및 label 입력 margin변경

### DIFF
--- a/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
@@ -208,7 +208,7 @@ export default function LabelEditBox({
     >
       <EditHeader>
         <ItemBox>
-          <LabelTag color={label.color}>{label.name}</LabelTag>
+          <LabelTag color={label.color}>{isNew ? 'Label preview' : label.name}</LabelTag>
         </ItemBox>
         <ItemBox>
           {label.no ? (

--- a/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
+++ b/frontend/src/components/LabelBox/LabelItemBox/LabelEditBox/LabelEditBox.js
@@ -47,7 +47,7 @@ const EditBody = styled.div`
   ${flex('space-between')}
 
   & > * {
-    margin: 0 10px;
+    margin-right: 20px;
   }
 `;
 

--- a/frontend/src/components/MilestoneList/MilestoneItem/MilestoneItem.js
+++ b/frontend/src/components/MilestoneList/MilestoneItem/MilestoneItem.js
@@ -5,6 +5,7 @@ import CalenderIcon from '@imgs/milestone-calendar.svg';
 import { useHistory } from 'react-router-dom';
 import { milestoneService } from '@services';
 import { getFormattedDueDate, getPercentage } from '@lib/utils';
+import { ProgressBar } from '@components';
 
 const Container = styled.div`
   width: 100%;
@@ -61,12 +62,6 @@ const ProgressBox = styled.div`
   border-top: 1px solid ${colors.borderColorSecondary};
   padding: 15px 20px;
   width: 420px;
-`;
-
-const ProgressBar = styled.progress`
-  height: 20px;
-  width: 420px;
-  color: ${colors.submitColor};
 `;
 
 const Status = styled.div`
@@ -198,7 +193,7 @@ export default function MilestoneItem({
             </Meta>
           </Title>
           <ProgressBox>
-            <ProgressBar max="100" value={percentage}></ProgressBar>
+            <ProgressBar percentage={percentage} />
             <div>
               <Status>
                 <span>{percentage}%</span>

--- a/frontend/src/components/MilestoneList/MilestoneItem/MilestoneItem.js
+++ b/frontend/src/components/MilestoneList/MilestoneItem/MilestoneItem.js
@@ -61,7 +61,7 @@ const ProgressBox = styled.div`
   border-right: 1px solid ${colors.borderColorSecondary};
   border-top: 1px solid ${colors.borderColorSecondary};
   padding: 15px 20px;
-  width: 420px;
+  width: 550px;
 `;
 
 const Status = styled.div`

--- a/frontend/src/components/common/ProgressBar/ProgressBar.js
+++ b/frontend/src/components/common/ProgressBar/ProgressBar.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from 'styled-components';
+import { colors } from '@styles/variables';
+
+const ProgressBarBackground = styled.span`
+  height: 10px;
+  display: flex;
+  overflow: hidden;
+  background-color: ${colors.borderColor};
+  border-radius: 6px;
+  margin-bottom: 8px;
+  margin-top: 4px;
+`;
+
+const Progress = styled.span`
+  width: ${props => props.width};
+  background-color: ${colors.issueGreen};
+`;
+
+export default function ProgressBar({ percentage }) {
+  return (
+    <>
+      <ProgressBarBackground>
+        <Progress width={'' + percentage + '%'}></Progress>
+      </ProgressBarBackground>
+    </>
+  );
+}

--- a/frontend/src/components/common/index.js
+++ b/frontend/src/components/common/index.js
@@ -3,3 +3,4 @@ export { default as OpenIcon } from './OpenIcon/OpenIcon';
 export { default as LabelTag } from './LabelTag/LabelTag';
 export { default as OptionSelectModal } from './OptionSelectModal/OptionSelectModal';
 export { default as LabelMilestoneControls } from './LabelMilestoneControls/LabelMilestoneControls';
+export { default as ProgressBar } from './ProgressBar/ProgressBar';


### PR DESCRIPTION
## 스크린샷
### ProgressBar변경
![image](https://user-images.githubusercontent.com/37579982/98888881-29587480-24dc-11eb-9e54-b6f4949a523c.png)

### label 수정
![image](https://user-images.githubusercontent.com/37579982/98888538-84d63280-24db-11eb-9f19-fdd4ee65651f.png)

- 공통 컴포넌트에 span태그로 만든 ProgressBar추가하고 마일스톤페이지의 ProgressBar교체하였습니다. 이슈사이드바의 progressbar도 바꿔보려고 했는데 마음대로 안되네요ㅠㅠ
- label 입력부분 margin수정하였습니다. 어제까진 분명 레이블 새로 추가하는 부분의 레이블 태그에 Label preview가 들어가있었던 것 같은데 오늘 보니까 사라져서 수정해보았습니다,,,,,,